### PR TITLE
Fix switch not updating on props change

### DIFF
--- a/src/Switch.js
+++ b/src/Switch.js
@@ -63,6 +63,14 @@ class AppSwitch extends Component {
     }
   }
 
+  componentDidUpdate(prevProps) {
+    if (this.props.checked !== prevProps.checked) {
+      this.setState({
+        checked: this.props.checked
+      })
+    }
+  }
+
   render() {
     const { className, disabled, color, name, label, outline, size, required, type, value, dataOn, dataOff, variant, ...attributes } = this.props;
 


### PR DESCRIPTION
Sometimes a switch must change an external state that triggers a re-render on the switch itself. Having a component state initialized from props at startup and re-initialized when those props change is always a best practice IMHO.