### PR TITLE
sidebar badge on parent menus

### DIFF
--- a/demo/src/scss/style.css
+++ b/demo/src/scss/style.css
@@ -11656,6 +11656,10 @@ canvas {
   margin-top: 2px;
 }
 
+.sidebar .nav-link.nav-dropdown-toggle .badge {
+  margin-right: 16px;
+}
+
 .sidebar .nav-link.active {
   color: #fff;
   background: #3a4248;

--- a/src/SidebarNav.js
+++ b/src/SidebarNav.js
@@ -111,7 +111,7 @@ class AppSidebarNav extends Component {
     const classIcon = classNames('nav-icon', item.icon);
     return (
       <li key={key} className={this.activeRoute(item.url, this.props)}>
-        <a className="nav-link nav-dropdown-toggle" href="#" onClick={this.handleClick}><i className={classIcon} />{item.name}</a>
+        <a className="nav-link nav-dropdown-toggle" href="#" onClick={this.handleClick}><i className={classIcon} />{item.name}{this.navBadge(item.badge)}</a>
         <ul className="nav-dropdown-items">
           {this.navList(item.children)}
         </ul>


### PR DESCRIPTION
**Objective:**
Badges on sidebar menus with children.

**To test badge on sidebar's parent menu:**
Temporarily change data in ./demo/src/_nav.js to:

```
export default {
  items: [
    {
      name: 'Dashboard',
      url: '/dashboard',
      icon: 'cui-speedometer icons',
      badge: {
        variant: 'info',
        text: 'NEW'
      }
    },
    {
      name: 'Category',
      url: '/category',
      icon: 'cui-speedometer icons',
      badge: {
        variant: 'danger',
        text: '2'
      },
      children: [
        {
          name: 'Sub Category 1',
          url: '/sub-category-1',
          icon: 'cui-speedometer icons'
        },
        {
          name: 'Sub Category 2',
          url: '/sub-category-2',
          icon: 'cui-speedometer icons',
          badge: {
            variant: 'danger',
            text: '1'
          }
        },
        {
          name: 'Sub Category 3',
          url: '/sub-category-3',
          icon: 'cui-speedometer icons',
          badge: {
            variant: 'danger',
            text: '1'
          }
        }
      ]
    }
  ]
};
```
closes feature/sidebar-badge-on-parent-menus