### PR TITLE
Fix/ios safari 9 sidebar toggle fix

### DIFF
--- a/src/Shared/toggle-classes.js
+++ b/src/Shared/toggle-classes.js
@@ -1,10 +1,10 @@
-export default function toggleClasses (toggleClass, classList, force) {
+export default function toggleClasses (toggleClass, classList) {
   const level = classList.indexOf(toggleClass)
   const removeClassList = classList.slice(0, level)
   removeClassList.map((className) => document.body.classList.remove(className))
   if (document.body.classList.contains(toggleClass)) {
-    document.body.classList.remove(toggleClass, force);
+    document.body.classList.remove(toggleClass);
   } else {
-    document.body.classList.add(toggleClass, force);
+    document.body.classList.add(toggleClass);
   }
 }

--- a/src/Shared/toggle-classes.js
+++ b/src/Shared/toggle-classes.js
@@ -2,5 +2,9 @@ export default function toggleClasses (toggleClass, classList, force) {
   const level = classList.indexOf(toggleClass)
   const removeClassList = classList.slice(0, level)
   removeClassList.map((className) => document.body.classList.remove(className))
-  document.body.classList.toggle(toggleClass, force)
+  if (document.body.classList.contains(toggleClass)) {
+    document.body.classList.remove(toggleClass, force);
+  } else {
+    document.body.classList.add(toggleClass, force);
+  }
 }


### PR DESCRIPTION
Hey!
I've found that on iOS 9 on Safari browser toggle function is not fully supported. It can correctly remove class but addition doesn't work. Proposing change to provide wider support for this core component.