### PR TITLE
v2.5.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 ### [@coreui/react](https://coreui.io/) changelog
 
+##### `v2.5.8`
+- chore(demo/polyfill): update to core-js v3
+
+###### dependencies update
+- update: `core-js` to `^3.6.5`
+- update: `react` to `^16.13.1`
+- update: `react-dom` to `^16.13.1`
+- update: `react-router-dom` to `^5.2.0`
+- update: `mutationobserver-shim` to `^0.3.5`
+- update: `eslint` to `^7.0.0`
+- update: `eslint-plugin-import` to `^2.20.2`
+- update: `eslint-plugin-react` to `^7.20.0`
+- update: `nwb` to `^0.24.7`
+- update: `react` to `^16.13.1`
+- update: `react-dom` to `^16.13.1`
+- update: `react-router-dom` to `^5.2.0`
+- update: `sinon` to `^9.0.2`
+
 ##### `v2.5.7`
 - fix(SidebarNav): add missing alternative icon config object
 

--- a/demo/src/containers/DefaultLayout/DefaultLayout.js
+++ b/demo/src/containers/DefaultLayout/DefaultLayout.js
@@ -92,7 +92,7 @@ class DefaultLayout extends Component {
           </AppAside>
         </div>
         <AppFooter>
-          <span><a href="https://coreui.io">CoreUI</a> &copy; 2019 creativeLabs</span>
+          <span><a href="https://coreui.io">CoreUI</a> &copy; 2020 creativeLabs</span>
           <span className="ml-auto">Powered by <a href="https://coreui.io/react">CoreUI for React</a></span>
         </AppFooter>
       </div>

--- a/demo/src/polyfill.js
+++ b/demo/src/polyfill.js
@@ -3,28 +3,27 @@
 */
 
 /** IE9, IE10 and IE11 requires all of the following polyfills. **/
-// import 'core-js/es6/symbol'
-// import 'core-js/es6/object'
-// import 'core-js/es6/function'
-// import 'core-js/es6/parse-int'
-// import 'core-js/es6/parse-float'
-// import 'core-js/es6/number'
-// import 'core-js/es6/math'
-// import 'core-js/es6/string'
-// import 'core-js/es6/date'
 import 'core-js/es/array'
-// import 'core-js/es6/regexp'
+// import 'core-js/es/date'
+// import 'core-js/es/function'
 import 'core-js/es/map'
-// import 'core-js/es6/weak-map'
-import 'core-js/es/set'
+// import 'core-js/es/math'
+// import 'core-js/es/number'
 import 'core-js/es/object'
+// import 'core-js/es/parse-int'
+// import 'core-js/es/parse-float'
+// import 'core-js/es/regexp'
+import 'core-js/es/set'
+// import 'core-js/es/string'
+// import 'core-js/es/symbol'
+// import 'core-js/es/weak-map'
 
 /** IE10 and IE11 requires the following for the Reflect API. */
-// import 'core-js/es6/reflect'
+// import 'core-js/es/reflect'
 
 /** Evergreen browsers require these. **/
 // Used for reflect-metadata in JIT. If you use AOT (and only Angular decorators), you can remove.
-// import 'core-js/es7/reflect'
+// import 'core-js/es/reflect'
 
 // CustomEvent() constructor functionality in IE9, IE10, IE11
 (function () {

--- a/package.json
+++ b/package.json
@@ -36,32 +36,32 @@
   },
   "dependencies": {
     "classnames": "^2.2.6",
-    "core-js": "^3.0.0",
+    "core-js": "^3.6.5",
     "prop-types": "^15.7.2",
     "react-onclickout": "^2.0.8",
     "react-perfect-scrollbar": "~1.5.8"
   },
   "peerDependencies": {
     "@coreui/coreui": "^2.1.16",
-    "react": "^16.12.0",
-    "react-dom": "^16.12.0",
-    "react-router-dom": "^5.1.2",
-    "mutationobserver-shim": "^0.3.3"
+    "react": "^16.13.1",
+    "react-dom": "^16.13.1",
+    "react-router-dom": "^5.2.0",
+    "mutationobserver-shim": "^0.3.5"
   },
   "devDependencies": {
     "@coreui/icons": "~0.3.0",
     "babel-eslint": "^10.1.0",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.2",
-    "eslint": "^5.16.0",
-    "eslint-plugin-import": "^2.20.1",
-    "eslint-plugin-react": "^7.18.3",
-    "nwb": "^0.23.0",
-    "react": "^16.13.0",
-    "react-dom": "^16.13.0",
-    "react-router-dom": "^5.1.2",
+    "eslint": "^7.0.0",
+    "eslint-plugin-import": "^2.20.2",
+    "eslint-plugin-react": "^7.20.0",
+    "nwb": "^0.24.7",
+    "react": "^16.13.1",
+    "react-dom": "^16.13.1",
+    "react-router-dom": "^5.2.0",
     "reactstrap": "^8.4.1",
-    "sinon": "^5.1.1"
+    "sinon": "^9.0.2"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coreui/react",
-  "version": "2.5.7",
+  "version": "2.5.8",
   "description": "CoreUI React Bootstrap 4 components",
   "license": "MIT",
   "author": {


### PR DESCRIPTION
##### `v2.5.8`
- chore(demo/polyfill): update to core-js v3 - thanks @barslev 

###### dependencies update
- update: `core-js` to `^3.6.5`
- update: `react` to `^16.13.1`
- update: `react-dom` to `^16.13.1`
- update: `react-router-dom` to `^5.2.0`
- update: `mutationobserver-shim` to `^0.3.5`
- update: `eslint` to `^7.0.0`
- update: `eslint-plugin-import` to `^2.20.2`
- update: `eslint-plugin-react` to `^7.20.0`
- update: `nwb` to `^0.24.7`
- update: `react` to `^16.13.1`
- update: `react-dom` to `^16.13.1`
- update: `react-router-dom` to `^5.2.0`
- update: `sinon` to `^9.0.2`