### PR TITLE
fix: CDataTable: set select default value to perPageItems if possible

### DIFF
--- a/src/table/CDataTable.js
+++ b/src/table/CDataTable.js
@@ -451,10 +451,8 @@ const CDataTable = props => {
               className="form-control"
               onChange={paginationChange}
               aria-label="changes number of visible items"
+              defaultValue={perPageItems}
             >
-              <option value="" disabled hidden>
-                {perPageItems}
-              </option>
               { paginationSelect.values.map((number, key)=>{
                 return (
                   <option


### PR DESCRIPTION
When CDataTable is being created with itemsPerPageSelect prop, it will always show the first item in the select's options.  
There was a hidden option, which I removed and changed the default to perPageItems.  
If there is no matching value in the array, then it will select the first from the options.