### PR TITLE
Enable scrollable modals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file. Dates are displayed in UTC.
 
+#### [3.3.2](https://github.com/coreui/coreui-react/compare/3.3.1...3.3.2)
+
+> 24 October 2020
+
+- chore: 3.3.2 version release [`fbf5379`](https://github.com/coreui/coreui-react/commit/fbf537971f7e83729832939ec979818d9a608dfe)
+- chore: dependencies update [`b3b5410`](https://github.com/coreui/coreui-react/commit/b3b54105bfc31cd60c84ce7418f5e1dced19ad6c)
+- test: fix test configuration, update snapshots [`81a4d7f`](https://github.com/coreui/coreui-react/commit/81a4d7f5f38cbee457ca4368fb1e40cbffb09cf8)
+- test: update tabs tests [`39b4284`](https://github.com/coreui/coreui-react/commit/39b4284b98cb507c6a83860f218f42a559d99532)
+- chore: delete test snapshots from es build [`b40c300`](https://github.com/coreui/coreui-react/commit/b40c300261b91c440543fbb477fc8ed6738cc2a9)
+- test: fix tooltip tests [`44839c9`](https://github.com/coreui/coreui-react/commit/44839c97fab34d645e424f33cec5e6bd18d525e3)
+- test: comment out some broken tests as todo [`64f7387`](https://github.com/coreui/coreui-react/commit/64f73871ff1c33f07adffc058c161e517db29167)
+- fix: CTabPane: fix 'active' prop, refactor component [`7fa04f8`](https://github.com/coreui/coreui-react/commit/7fa04f8311b7820e2b50a657d538f8d5a18c188e)
+- chore: exclude test files from es build [`cf34f54`](https://github.com/coreui/coreui-react/commit/cf34f549844d842d67e95da0f8ce98adc1e32549)
+- chore: update changelog [`edd558a`](https://github.com/coreui/coreui-react/commit/edd558a05dcbe7219cfdbff18b793c70b586147d)
+- chore: Merge branch 'dev-tests' into dev [`b47d3d5`](https://github.com/coreui/coreui-react/commit/b47d3d57de935dc753ed6b991828db067bdabcce)
+- chore: Merge branch 'dev-storybook' into dev [`27c4629`](https://github.com/coreui/coreui-react/commit/27c462980c3845d204c48f14eece0618b2021430)
+
 #### [3.3.1](https://github.com/coreui/coreui-react/compare/3.3.0...3.3.1)
 
 > 15 October 2020

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coreui/react",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "description": "CoreUI React Bootstrap 4 components",
   "license": "MIT",
   "author": {

--- a/src/modal/CModal.js
+++ b/src/modal/CModal.js
@@ -29,6 +29,7 @@ const CModal = props => {
     onClosed,
     addContentClass,
     onClose,
+    scrollable,
     ...attributes
   } = props
 
@@ -71,6 +72,7 @@ const CModal = props => {
 
   const dialogClasses = classNames(
     'modal-dialog', {
+      'modal-dialog-scrollable': scrollable,
       'modal-dialog-centered': centered,
       [`modal-${size}`]: size
     }
@@ -115,8 +117,8 @@ const CModal = props => {
             >
               <div className={dialogClasses} role="document">
                 <div
-                  {...attributes} 
-                  className={contentClasses} 
+                  {...attributes}
+                  className={contentClasses}
                   ref={innerRef}
                 >
                   <Context.Provider value={{close}}>
@@ -127,7 +129,7 @@ const CModal = props => {
             </div>
           )
         }}
-        
+
       </Transition>
       { backdrop && isOpen && <div className={backdropClasses}></div> }
     </div>
@@ -142,14 +144,15 @@ CModal.propTypes = {
   centered: PropTypes.bool,
   size: PropTypes.oneOf(['', 'sm', 'lg', 'xl']),
   backdrop: PropTypes.bool,
-  color: PropTypes.string, 
+  color: PropTypes.string,
   borderColor: PropTypes.string,
   onOpened: PropTypes.func,
   onClosed: PropTypes.func,
   fade: PropTypes.bool,
   closeOnBackdrop: PropTypes.bool,
   onClose: PropTypes.func,
-  addContentClass: PropTypes.string
+  addContentClass: PropTypes.string,
+  scrollable: PropTypes.bool,
 }
 
 CModal.defaultProps = {


### PR DESCRIPTION
Adds support for `scrollable` prop to CModal, which sets the `modal-dialog-scrollbar` class on a modal dialog, which enables scrollable modals https://getbootstrap.com/docs/4.3/components/modal/#scrolling-long-content

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/coreui/coreui-react/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
