### PR TITLE
Fix DataTable not overwriting default CPagination props

### DIFF
--- a/src/table/CDataTable.js
+++ b/src/table/CDataTable.js
@@ -589,11 +589,11 @@ const CDataTable = props => {
 
 { pagination &&
   <CPagination
-    {...paginationProps}
     style={{display: totalPages > 1 ? 'inline' : 'none'}}
     onActivePageChange={(page) => { setPage(page) }}
     pages={totalPages}
     activePage={page}
+    {...paginationProps}
   />
 }
 </React.Fragment>


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/coreui/coreui-react/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Docs say `pagination:` `Enables default pagination. Set to true for default setup or pass object with additional CPagination props.`, but when CPagination props object is passed to the component the defaults are not overwritten. 

