### PR TITLE
Updated CModal to support mountOnEnter, unmountOnExit

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -646,6 +646,8 @@ interface CModal extends Omit< HTMLPropsNoClassName, 'size'> {
   onClose?: Function;
   addContentClass?: string;
   scrollable?: boolean;
+  mountOnEnter?: boolean;
+  unmountOnExit?: boolean;
 }
 
 interface CModalBody extends HTMLPropsNoClassName {

--- a/src/modal/CModal.js
+++ b/src/modal/CModal.js
@@ -31,6 +31,8 @@ const CModal = props => {
     onClose,
     className,
     scrollable,
+    mountOnEnter,
+    unmountOnExit,
     ...attributes
   } = props
 
@@ -102,6 +104,8 @@ const CModal = props => {
         onExited={onExited}
         timeout={fade ? 150 : 0}
         nodeRef={nodeRef}
+        mountOnEnter={mountOnEnter}
+        unmountOnExit={unmountOnExit}
       >
         {(status) => {
           let transitionClass = getTransitionClass(status)
@@ -155,12 +159,16 @@ CModal.propTypes = {
   onClose: PropTypes.func,
   addContentClass: PropTypes.string,
   scrollable: PropTypes.bool,
+  mountOnEnter: PropTypes.bool,
+  unmountOnExit: PropTypes.bool,
 }
 
 CModal.defaultProps = {
   backdrop: true,
   fade: true,
-  closeOnBackdrop: true
+  closeOnBackdrop: true,
+  mountOnEnter: false,
+  unmountOnExit: false,
 }
 
 export default CModal


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/coreui/coreui-react/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `develop` branch (or to a previous version branch), _not_ the `master` branch
- [X] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [X] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Hey CoreUI team!

We love your library, and enjoy using it.

One of the issue we came upon quite a few times is having all CModal children mounted even if the modal is hidden.
This PR introduces 2 new props: `mountOnEnter` and `unmountOnExit`, which are just forwarded to `react-transition-group`s `Transition` component, thus enabling the users to choose.

Default functionality hasn't been changed.

Let me know what you think!
