### PR TITLE
fix: CTable put 0 data in but not add

### DIFF
--- a/packages/coreui-react/src/components/table/CTable.tsx
+++ b/packages/coreui-react/src/components/table/CTable.tsx
@@ -201,7 +201,7 @@ export const CTable = forwardRef<HTMLTableElement, CTableProps>(
                 <CTableRow {...(item._props && { ...item._props })} key={index}>
                   {columnNames &&
                     columnNames.map((colName: string, index: number) => {
-                      return item[colName] ? (
+                      return item[colName] !== undefined && item[colName] !== null ? (
                         <CTableDataCell
                           {...(item._cellProps && {
                             ...(item._cellProps['all'] && { ...item._cellProps['all'] }),

--- a/packages/coreui-react/src/components/table/CTable.tsx
+++ b/packages/coreui-react/src/components/table/CTable.tsx
@@ -201,7 +201,7 @@ export const CTable = forwardRef<HTMLTableElement, CTableProps>(
                 <CTableRow {...(item._props && { ...item._props })} key={index}>
                   {columnNames &&
                     columnNames.map((colName: string, index: number) => {
-                      return item[colName] !== undefined && item[colName] !== null ? (
+                      return item[colName] !== undefined ? (
                         <CTableDataCell
                           {...(item._cellProps && {
                             ...(item._cellProps['all'] && { ...item._cellProps['all'] }),


### PR DESCRIPTION
CTable put 0 data in but not add

Existing conditional statements return false if the value is empty or zero.
But the user needs to see zeros and empty values in the row as well
So we changed the condition

Fixes #357