### PR TITLE
Fix sidebar issues hapenning when changing from sidebar-narrow-unfoldable desktop to mobile

### DIFF
--- a/packages/coreui-react/src/components/sidebar/CSidebar.tsx
+++ b/packages/coreui-react/src/components/sidebar/CSidebar.tsx
@@ -75,7 +75,7 @@ export const CSidebar = forwardRef<HTMLDivElement, CSidebarProps>(
     const sidebarRef = useRef<HTMLDivElement>(null)
     const forkedRef = useForkedRef(ref, sidebarRef)
     const [mobile, setMobile] = useState(false)
-    const [_visible, setVisible] = useState(visible)
+    const [desktopVisible, setDesktopVisible] = useState(visible)
     const [mobileVisible, setMobileVisible] = useState<boolean>(false)
     const [inViewport, setInViewport] = useState<boolean>()
 
@@ -83,7 +83,7 @@ export const CSidebar = forwardRef<HTMLDivElement, CSidebarProps>(
       sidebarRef.current && setMobile(isOnMobile(sidebarRef.current))
       sidebarRef.current && isOnMobile(sidebarRef.current)
         ? setMobileVisible(visible ?? false)
-        : setVisible(visible)
+        : setDesktopVisible(visible)
     }, [visible])
 
     useEffect(() => {
@@ -136,6 +136,7 @@ export const CSidebar = forwardRef<HTMLDivElement, CSidebarProps>(
         handleHide()
       }
     }
+
     const handleClickOutside = (event: Event) => {
       if (
         mobile &&
@@ -167,7 +168,7 @@ export const CSidebar = forwardRef<HTMLDivElement, CSidebarProps>(
               [`sidebar-${size}`]: size,
               'sidebar-narrow-unfoldable': unfoldable,
               show: mobileVisible === true && mobile,
-              hide: _visible === false && !mobile,
+              hide: desktopVisible === false && !mobile,
             },
             className,
           )}

--- a/packages/coreui-react/src/components/sidebar/CSidebar.tsx
+++ b/packages/coreui-react/src/components/sidebar/CSidebar.tsx
@@ -76,12 +76,14 @@ export const CSidebar = forwardRef<HTMLDivElement, CSidebarProps>(
     const forkedRef = useForkedRef(ref, sidebarRef)
     const [mobile, setMobile] = useState(false)
     const [_visible, setVisible] = useState(visible)
+    const [mobileVisible, setMobileVisible] = useState<boolean>(false)
     const [inViewport, setInViewport] = useState<boolean>()
 
     useEffect(() => {
       sidebarRef.current && setMobile(isOnMobile(sidebarRef.current))
-
-      setVisible(visible)
+      sidebarRef.current && isOnMobile(sidebarRef.current)
+        ? setMobileVisible(visible ?? false)
+        : setVisible(visible)
     }, [visible])
 
     useEffect(() => {
@@ -91,11 +93,8 @@ export const CSidebar = forwardRef<HTMLDivElement, CSidebarProps>(
     }, [inViewport])
 
     useEffect(() => {
-      mobile && visible && setVisible(false)
-    }, [mobile])
-
-    useEffect(() => {
       sidebarRef.current && setMobile(isOnMobile(sidebarRef.current))
+      sidebarRef.current && !isOnMobile(sidebarRef.current) && setMobileVisible(false)
       sidebarRef.current && setInViewport(isInViewport(sidebarRef.current))
 
       window.addEventListener('resize', handleResize)
@@ -120,7 +119,7 @@ export const CSidebar = forwardRef<HTMLDivElement, CSidebarProps>(
     })
 
     const handleHide = () => {
-      setVisible(false)
+      setMobileVisible(false)
     }
 
     const handleResize = () => {
@@ -167,7 +166,7 @@ export const CSidebar = forwardRef<HTMLDivElement, CSidebarProps>(
               [`sidebar-${position}`]: position,
               [`sidebar-${size}`]: size,
               'sidebar-narrow-unfoldable': unfoldable,
-              show: _visible === true && mobile,
+              show: mobileVisible === true && mobile,
               hide: _visible === false && !mobile,
             },
             className,
@@ -180,7 +179,7 @@ export const CSidebar = forwardRef<HTMLDivElement, CSidebarProps>(
         {typeof window !== 'undefined' &&
           mobile &&
           createPortal(
-            <CBackdrop className="sidebar-backdrop" visible={_visible} />,
+            <CBackdrop className="sidebar-backdrop" visible={mobileVisible} />,
             document.body,
           )}
       </>


### PR DESCRIPTION
Hi!

When the sidebar is visible in unfoldable state and the browser is reduced until modile dimensions, there is a strange animation which occurs due to margin-left differencies.

After researching about this topic, I concluded that the main issue is caused by the ``visible`` state of the ``CSidebar`` because it is the same for Desktop and for  Mobile.

I manage to fix the code by creating a new state called ``mobileVisible`` which is ``False`` by default and it is only modified when the browser has mobile dimensions. It notifies all the visible changes to component by the ``onVisibleChange`` function, so it continious working properly and the annoying effect disappears.