### PR TITLE
docs: fixed typo

### DIFF
--- a/packages/docs/content/forms/input-mask.mdx
+++ b/packages/docs/content/forms/input-mask.mdx
@@ -1,7 +1,7 @@
 ---
 title: React Input Mask
 name: Input mask
-description: React input masks allow you to regulate the format of data entered. Yyou can enhance data entry accuracy by implementing react input masks for fields with consistent formatting requirements. This ensures that users input data correctly, such as accurately formatted phone numbers in a designated phone number field.
+description: React input masks allow you to regulate the format of data entered. You can enhance data entry accuracy by implementing react input masks for fields with consistent formatting requirements. This ensures that users input data correctly, such as accurately formatted phone numbers in a designated phone number field.
 menu: Forms
 route: /forms/input-mask
 ---


### PR DESCRIPTION
Fixed a little typo in the documentation at forms/input-mask.
Typo: `yyou -> you`