### PR TITLE
fix(CNavGroup): set default `height` state to 0

### DIFF
--- a/packages/coreui-react/src/components/nav/CNavGroup.tsx
+++ b/packages/coreui-react/src/components/nav/CNavGroup.tsx
@@ -58,7 +58,7 @@ export const CNavGroup: PolymorphicRefForwardingComponent<'li', CNavGroupProps> 
   HTMLDivElement | HTMLLIElement,
   CNavGroupProps
 >(({ children, as: Component = 'li', className, compact, idx, toggler, visible, ...rest }, ref) => {
-  const [height, setHeight] = useState<number | string>()
+  const [height, setHeight] = useState<number | string>(0)
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const navItemsRef = useRef<any>(null)
 


### PR DESCRIPTION
Closes https://github.com/coreui/coreui-react/issues/410
The root cause of the issue is that height is `undefined` while the transition state is `exiting` and thus the style sets height to `undefined`. Then when the transition starts on opening the dropdown, the height is instantly set to `auto` meaning there's no startpoint to transition from.
This fix is a suggestion. This can also be solved using props or more complex style conditions.