### PR TITLE
fix(CListGroup): allow passing props

### DIFF
--- a/packages/coreui-react/src/components/list-group/CListGroup.tsx
+++ b/packages/coreui-react/src/components/list-group/CListGroup.tsx
@@ -32,7 +32,7 @@ export interface CListGroupProps extends HTMLAttributes<HTMLDivElement | HTMLULi
 export const CListGroup: PolymorphicRefForwardingComponent<'ul', CListGroupProps> = forwardRef<
   HTMLDivElement | HTMLUListElement,
   CListGroupProps
->(({ children, as: Component = 'ul', className, flush, layout }, ref) => {
+>(({ children, as: Component = 'ul', className, flush, layout, ...rest }, ref) => {
   return (
     <Component
       className={classNames(
@@ -43,6 +43,7 @@ export const CListGroup: PolymorphicRefForwardingComponent<'ul', CListGroupProps
         },
         className,
       )}
+      {...rest}
       ref={ref}
     >
       {children}


### PR DESCRIPTION
Adds extra props passing to the base CListGroup component, solves an issue similar to https://github.com/coreui/coreui-react/issues/406 described for CRow.