### PR TITLE
fix: popover with react18

### DIFF
--- a/packages/coreui-react/src/components/popover/CPopover.tsx
+++ b/packages/coreui-react/src/components/popover/CPopover.tsx
@@ -136,7 +136,26 @@ export const CPopover = forwardRef<HTMLDivElement, CPopoverProps>(
     useEffect(() => {
       if (_visible) {
         setMounted(true)
+      }
 
+      return () => {
+        if (popoverRef.current) {
+          popoverRef.current.classList.remove('show')
+          onHide && onHide()
+          executeAfterTransition(() => {
+            if (popoverRef.current) {
+              popoverRef.current.style.display = 'none'
+            }
+
+            destroyPopper()
+            setMounted(false)
+          }, popoverRef.current)
+        }
+      }
+    }, [_visible])
+    useEffect(() => {
+      if (mounted) {
+        // On the render after `setMounted(true)`, the popoverRef will be populated
         if (popoverRef.current) {
           popoverRef.current.classList.remove('fade', 'show')
           destroyPopper()
@@ -155,22 +174,7 @@ export const CPopover = forwardRef<HTMLDivElement, CPopoverProps>(
           }
         }, _delay.show)
       }
-
-      return () => {
-        if (popoverRef.current) {
-          popoverRef.current.classList.remove('show')
-          onHide && onHide()
-          executeAfterTransition(() => {
-            if (popoverRef.current) {
-              popoverRef.current.style.display = 'none'
-            }
-
-            destroyPopper()
-            setMounted(false)
-          }, popoverRef.current)
-        }
-      }
-    }, [_visible])
+    }, [mounted])
 
     return (
       <>


### PR DESCRIPTION
When using coreui with the new render flow for react 18, popovers fail to show in Safari (macos 15, safari 18.0.1)
This appears to be because of the new [Automatic batching](https://react.dev/blog/2022/03/29/react-v18#new-feature-automatic-batching), causing the popover to try to initialise itself before the ref to the div has been set.

This is a simple/naive split of the `useEffect` to force the initialisation to be done in the render where the div ref will be setup