### PR TITLE
fix(CBadge): update propTypes to use ElementType for 'as' prop

### DIFF
--- a/packages/coreui-react/src/components/badge/CBadge.tsx
+++ b/packages/coreui-react/src/components/badge/CBadge.tsx
@@ -96,7 +96,7 @@ export const CBadge: PolymorphicRefForwardingComponent<'span', CBadgeProps> = fo
 )
 
 CBadge.propTypes = {
-  as: PropTypes.string,
+  as: PropTypes.ElementType,
   children: PropTypes.node,
   className: PropTypes.string,
   color: colorPropType,


### PR DESCRIPTION
Update CBadge component to use ElementType for 'as' instead of string.

Fix: #419