### PR TITLE
docs: fixed typo

### DIFF
--- a/packages/docs/content/components/modal/index.mdx
+++ b/packages/docs/content/components/modal/index.mdx
@@ -128,9 +128,9 @@ Modals have three optional sizes, available via modifier classes to be placed on
 
 ## Fullscreen Modal
 
-Another override is the option to pop up a React modal component that covers the user viewport, available via property `fullscrean`.
+Another override is the option to pop up a React modal component that covers the user viewport, available via property `fullscreen`.
 
-| Fullscrean | Availability   |
+| Fullscreen | Availability   |
 | ---------- | -------------- |
 | `true`     | Always         |
 | `'sm'`     | Below `576px`  |


### PR DESCRIPTION
Fixed a little typo in the documentation at components/modal in the fullscreen-modal section:
`fullscrean` -> `fullscreen`