### PR TITLE
docs: add AddedIn badge component

### DIFF
--- a/packages/docs/content/components/navs-tabs/styling.mdx
+++ b/packages/docs/content/components/navs-tabs/styling.mdx
@@ -21,13 +21,13 @@ On the `.nav-pills` modifier class:
 
 <ScssDocs file="_nav.scss" capture="nav-pills-css-vars"/>
 
-<small className="d-inline-flex mb-3 px-2 py-1 fw-semibold text-success bg-success bg-opacity-10 border border-success border-opacity-10 rounded-2">Added in v5.0.0</small>
+<AddedIn version="5.0.0" />
 
 On the `.nav-underline` modifier class:
 
 <ScssDocs file="_nav.scss" capture="nav-underline-css-vars"/>
 
-<small className="d-inline-flex mb-3 px-2 py-1 fw-semibold text-success bg-success bg-opacity-10 border border-success border-opacity-10 rounded-2">Added in v5.0.0</small>
+<AddedIn version="5.0.0" />
 
 On the `.nav-underline-border` modifier class:
 

--- a/packages/docs/content/components/tabs/styling.mdx
+++ b/packages/docs/content/components/tabs/styling.mdx
@@ -21,13 +21,13 @@ On the `.nav-pills` modifier class:
 
 <ScssDocs file="_nav.scss" capture="nav-pills-css-vars"/>
 
-<small className="d-inline-flex mb-3 px-2 py-1 fw-semibold text-success bg-success bg-opacity-10 border border-success border-opacity-10 rounded-2">Added in v5.0.0</small>
+<AddedIn version="5.0.0" />
 
 On the `.nav-underline` modifier class:
 
 <ScssDocs file="_nav.scss" capture="nav-underline-css-vars"/>
 
-<small className="d-inline-flex mb-3 px-2 py-1 fw-semibold text-success bg-success bg-opacity-10 border border-success border-opacity-10 rounded-2">Added in v5.0.0</small>
+<AddedIn version="5.0.0" />
 
 On the `.nav-underline-border` modifier class:
 

--- a/packages/docs/src/components/AddedIn.tsx
+++ b/packages/docs/src/components/AddedIn.tsx
@@ -1,0 +1,15 @@
+import React, { FC } from 'react'
+
+export interface AddedInProps {
+  version: string
+}
+
+const AddedIn: FC<AddedInProps> = ({ version }) => (
+  <small className="d-inline-flex mb-3 px-2 py-1 fw-semibold text-success bg-success bg-opacity-10 border border-success border-opacity-10 rounded-2">
+    Added in v{version}
+  </small>
+)
+
+AddedIn.displayName = 'AddedIn'
+
+export default AddedIn

--- a/packages/docs/src/components/index.ts
+++ b/packages/docs/src/components/index.ts
@@ -1,3 +1,4 @@
+import AddedIn from './AddedIn'
 import Ads from './Ads'
 import Banner from './Banner'
 import Callout from './Callout'
@@ -17,6 +18,7 @@ import { SidebarNav } from './SidebarNav'
 import Toc from './Toc'
 
 export {
+  AddedIn,
   Ads,
   Banner,
   Callout,

--- a/packages/docs/src/templates/MdxLayout.tsx
+++ b/packages/docs/src/templates/MdxLayout.tsx
@@ -2,6 +2,7 @@ import React, { FC, useMemo } from 'react'
 import { graphql, PageProps } from 'gatsby'
 import { MDXProvider } from '@mdx-js/react'
 import {
+  AddedIn,
   Callout,
   CodeBlock,
   ClassNamesDocs,
@@ -12,6 +13,7 @@ import {
   Seo,
 } from '../components'
 
+import { AddedInProps } from '../components/AddedIn'
 import { CalloutProps } from '../components/Callout'
 import { CodeBlockProps } from '../components/CodeBlock'
 import { ExampleProps } from '../components/Example'
@@ -50,6 +52,7 @@ interface Toc {
 const MdxLayout: FC<PageProps<DataProps>> = ({ children }) => {
   const components = useMemo(
     () => ({
+      AddedIn: (props: AddedInProps) => <AddedIn {...props} />,
       Callout: (props: CalloutProps) => {
         const { children, title, ...rest } = props
         return (


### PR DESCRIPTION
Adds the reusable `<AddedIn version="…" />` docs badge to the free repo (parity with coreui-react-pro). New `AddedIn.tsx` component, exported from `components/index.ts` and registered in `MdxLayout` so MDX pages can mark when a feature was added.