### PR TITLE
feat(CNavGroup): controlled visibility, onVisibleChange and context-based accordion

### DIFF
--- a/packages/coreui-react/src/components/nav/CNavGroup.tsx
+++ b/packages/coreui-react/src/components/nav/CNavGroup.tsx
@@ -6,6 +6,8 @@ import React, {
   ReactNode,
   useContext,
   useEffect,
+  useId,
+  useMemo,
   useRef,
   useState,
 } from 'react'
@@ -16,6 +18,7 @@ import type { TransitionStatus } from 'react-transition-group'
 
 import { PolymorphicRefForwardingComponent } from '../../helpers'
 
+import { CNavGroupContext } from './CNavGroupContext'
 import { CSidebarNavContext } from '../sidebar/CSidebarNavContext'
 export interface CNavGroupProps extends HTMLAttributes<HTMLDivElement | HTMLLIElement> {
   /**
@@ -33,145 +36,214 @@ export interface CNavGroupProps extends HTMLAttributes<HTMLDivElement | HTMLLIEl
    */
   compact?: boolean
   /**
+   * Callback fired when the user toggles the group. Receives the requested visibility. Provide
+   * it together with `visible` for controlled mode—update `visible` from here, or ignore the
+   * change to keep the group as is.
+   *
+   * @since 5.12.0
+   */
+  onVisibleChange?: (visible: boolean) => void
+  /**
    * Set group toggler label.
    */
   toggler?: string | ReactNode | (({ visible }: { visible: boolean }) => ReactNode)
   /**
-   * Show nav group items.
+   * Show nav group items. Acts as the initial state when used on its own, or as the controlled
+   * value when paired with `onVisibleChange`.
    */
   visible?: boolean
-  /**
-   * @ignore
-   */
-  idx?: string
 }
 
-const isInVisibleGroup = (el1: string, el2: string) => {
-  const array1 = el1.toString().split('.')
-  const array2 = el2.toString().split('.')
-
-  return array2.every((item, index) => item === array1[index])
-}
+const isPrefix = (chain: string[], other: string[]) =>
+  chain.every((id, index) => other[index] === id)
 
 export const CNavGroup: PolymorphicRefForwardingComponent<'li', CNavGroupProps> = forwardRef<
   HTMLDivElement | HTMLLIElement,
   CNavGroupProps
->(({ children, as: Component = 'li', className, compact, idx, toggler, visible, ...rest }, ref) => {
-  const [height, setHeight] = useState<number | string>(0)
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const navItemsRef = useRef<any>(null)
+>(
+  (
+    {
+      children,
+      as: Component = 'li',
+      className,
+      compact,
+      onVisibleChange,
+      toggler,
+      visible,
+      ...rest
+    },
+    ref
+  ) => {
+    const id = useId()
+    const parentChain = useContext(CNavGroupContext)
+    const chain = useMemo(() => [...parentChain, id], [parentChain, id])
 
-  const { visibleGroup, setVisibleGroup } = useContext(CSidebarNavContext)
+    const navContext = useContext(CSidebarNavContext)
+    const setOpenChain = navContext?.setOpenChain
 
-  const [_visible, setVisible] = useState(
-    Boolean(visible || (idx && visibleGroup && isInVisibleGroup(visibleGroup, idx)))
-  )
+    const [height, setHeight] = useState<number | string>(0)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const navItemsRef = useRef<any>(null)
 
-  useEffect(() => {
-    visible !== undefined && setVisible(visible)
-  }, [visible])
+    const [uncontrolledVisible, setUncontrolledVisible] = useState(Boolean(visible))
 
-  useEffect(() => {
-    visibleGroup && setVisible(Boolean(idx && visibleGroup && isInVisibleGroup(visibleGroup, idx)))
-  }, [idx, visibleGroup])
+    const controlled = visible !== undefined && onVisibleChange !== undefined
 
-  const handleTogglerOnCLick = (event: React.MouseEvent<HTMLElement>) => {
-    event.preventDefault()
-    setVisibleGroup(
-      _visible ? (idx?.toString().includes('.') ? idx.slice(0, idx.lastIndexOf('.')) : '') : idx
-    )
-    setVisible(!_visible)
-  }
+    const _visible = controlled
+      ? Boolean(visible)
+      : navContext
+        ? chain.length > 0 && isPrefix(chain, navContext.openChain)
+        : uncontrolledVisible
 
-  const style: CSSProperties = {
-    height: 0,
-  }
+    // Sync the accordion with the `visible` prop: seeds default-open groups and follows later
+    // changes (and keeps controlled groups in sync). `setOpenChain` is stable, so this does not
+    // re-run on unrelated accordion updates—letting a default-open group be collapsed manually.
+    useEffect(() => {
+      if (!setOpenChain || visible === undefined) {
+        return
+      }
 
-  const onEntering = () => {
-    navItemsRef.current && setHeight(navItemsRef.current.scrollHeight)
-  }
+      if (visible) {
+        setOpenChain((prev) => (chain.length > prev.length && isPrefix(prev, chain) ? chain : prev))
+      } else {
+        setOpenChain((prev) => (isPrefix(chain, prev) ? parentChain : prev))
+      }
+    }, [visible, setOpenChain, chain, parentChain])
 
-  const onEntered = () => {
-    setHeight('auto')
-  }
+    // Standalone (no sidebar): mirror the `visible` prop into local state.
+    useEffect(() => {
+      if (navContext || visible === undefined) {
+        return
+      }
 
-  const onExit = () => {
-    navItemsRef.current && setHeight(navItemsRef.current.scrollHeight)
-  }
+      setUncontrolledVisible(visible)
+    }, [visible, navContext])
 
-  const onExiting = () => {
-    // @ts-expect-error reflow is necessary to get correct height of the element
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const reflow = navItemsRef.current?.offsetHeight
-    setHeight(0)
-  }
+    // Accordion: when another branch opens, a controlled group must close too. As its
+    // visibility is owned by the parent, request the change through `onVisibleChange`.
+    useEffect(() => {
+      if (!controlled || !navContext || !visible) {
+        return
+      }
 
-  const onExited = () => {
-    setHeight(0)
-  }
+      const openHere = chain.length > 0 && isPrefix(chain, navContext.openChain)
+      if (!openHere && navContext.openChain.length > 0) {
+        onVisibleChange?.(false)
+      }
+    }, [controlled, navContext, visible, chain, onVisibleChange])
 
-  const transitionStyles = {
-    entering: { display: 'block', height: height },
-    entered: { display: 'block', height: height },
-    exiting: { display: 'block', height: height },
-    exited: { height: height },
-    unmounted: {},
-  }
+    const handleTogglerOnClick = (event: React.MouseEvent<HTMLElement>) => {
+      event.preventDefault()
+      const next = !_visible
 
-  const NavGroupItemsComponent = Component === 'li' ? 'ul' : 'div'
-  const togglerContent = typeof toggler === 'function' ? toggler({ visible: _visible }) : toggler
+      if (!controlled) {
+        if (setOpenChain) {
+          setOpenChain(next ? chain : parentChain)
+        } else {
+          setUncontrolledVisible(next)
+        }
+      }
 
-  return (
-    <Component
-      className={classNames('nav-group', { show: _visible }, className)}
-      {...rest}
-      ref={ref}
-    >
-      {toggler && (
-        <a
-          className="nav-link nav-group-toggle"
-          href="#"
-          onClick={(event) => handleTogglerOnCLick(event)}
+      onVisibleChange?.(next)
+    }
+
+    const style: CSSProperties = {
+      height: 0,
+    }
+
+    const onEntering = () => {
+      if (navItemsRef.current) {
+        setHeight(navItemsRef.current.scrollHeight)
+      }
+    }
+
+    const onEntered = () => {
+      setHeight('auto')
+    }
+
+    const onExit = () => {
+      if (navItemsRef.current) {
+        setHeight(navItemsRef.current.scrollHeight)
+      }
+    }
+
+    const onExiting = () => {
+      // @ts-expect-error reflow is necessary to get correct height of the element
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const reflow = navItemsRef.current?.offsetHeight
+      setHeight(0)
+    }
+
+    const onExited = () => {
+      setHeight(0)
+    }
+
+    const transitionStyles = {
+      entering: { display: 'block', height: height },
+      entered: { display: 'block', height: height },
+      exiting: { display: 'block', height: height },
+      exited: { height: height },
+      unmounted: {},
+    }
+
+    const NavGroupItemsComponent = Component === 'li' ? 'ul' : 'div'
+    const togglerContent = typeof toggler === 'function' ? toggler({ visible: _visible }) : toggler
+
+    return (
+      <CNavGroupContext.Provider value={chain}>
+        <Component
+          className={classNames('nav-group', { show: _visible }, className)}
+          {...rest}
+          ref={ref}
         >
-          {togglerContent}
-        </a>
-      )}
-      <Transition
-        appear
-        in={_visible}
-        nodeRef={navItemsRef}
-        onEntering={onEntering}
-        onEntered={onEntered}
-        onExit={onExit}
-        onExiting={onExiting}
-        onExited={onExited}
-        timeout={300}
-      >
-        {(state) => (
-          <NavGroupItemsComponent
-            className={classNames('nav-group-items', {
-              compact: compact,
-            })}
-            style={{
-              ...style,
-              ...transitionStyles[state as TransitionStatus],
-            }}
-            ref={navItemsRef}
+          {toggler && (
+            <a
+              aria-expanded={_visible}
+              className="nav-link nav-group-toggle"
+              href="#"
+              onClick={handleTogglerOnClick}
+            >
+              {togglerContent}
+            </a>
+          )}
+          <Transition
+            appear
+            in={_visible}
+            nodeRef={navItemsRef}
+            onEntering={onEntering}
+            onEntered={onEntered}
+            onExit={onExit}
+            onExiting={onExiting}
+            onExited={onExited}
+            timeout={300}
           >
-            {children}
-          </NavGroupItemsComponent>
-        )}
-      </Transition>
-    </Component>
-  )
-})
+            {(state) => (
+              <NavGroupItemsComponent
+                className={classNames('nav-group-items', {
+                  compact: compact,
+                })}
+                style={{
+                  ...style,
+                  ...transitionStyles[state as TransitionStatus],
+                }}
+                ref={navItemsRef}
+              >
+                {children}
+              </NavGroupItemsComponent>
+            )}
+          </Transition>
+        </Component>
+      </CNavGroupContext.Provider>
+    )
+  }
+)
 
 CNavGroup.propTypes = {
   as: PropTypes.elementType,
   children: PropTypes.node,
   className: PropTypes.string,
   compact: PropTypes.bool,
-  idx: PropTypes.string,
+  onVisibleChange: PropTypes.func,
   toggler: PropTypes.oneOfType([PropTypes.string, PropTypes.node, PropTypes.func]),
   visible: PropTypes.bool,
 }

--- a/packages/coreui-react/src/components/nav/CNavGroupContext.ts
+++ b/packages/coreui-react/src/components/nav/CNavGroupContext.ts
@@ -1,0 +1,8 @@
+import { createContext } from 'react'
+
+/**
+ * The chain of stable ids of the ancestor nav groups, from the root nav down to (and
+ * including) the closest parent `CNavGroup`. An empty array means the consumer is rendered
+ * directly under `CSidebarNav`, with no parent group.
+ */
+export const CNavGroupContext = createContext<string[]>([])

--- a/packages/coreui-react/src/components/nav/CNavLink.tsx
+++ b/packages/coreui-react/src/components/nav/CNavLink.tsx
@@ -3,16 +3,13 @@ import PropTypes from 'prop-types'
 import classNames from 'classnames'
 
 import { CLinkProps, CLink } from '../link/CLink'
+import { CNavGroupContext } from './CNavGroupContext'
 import { CSidebarNavContext } from '../sidebar/CSidebarNavContext'
 
 import { PolymorphicRefForwardingComponent } from '../../helpers'
 import { useForkedRef } from '../../hooks'
 
-export interface CNavLinkProps extends Omit<CLinkProps, 'idx'> {
-  /**
-   * @ignore
-   */
-  idx?: string
+export interface CNavLinkProps extends CLinkProps {
   /**
    * @ignore
    */
@@ -22,16 +19,36 @@ export interface CNavLinkProps extends Omit<CLinkProps, 'idx'> {
 export const CNavLink: PolymorphicRefForwardingComponent<'a', CNavLinkProps> = forwardRef<
   HTMLButtonElement | HTMLAnchorElement,
   CNavLinkProps
->(({ children, className, idx, ...rest }, ref) => {
+>(({ children, className, ...rest }, ref) => {
   const navLinkRef = useRef<HTMLAnchorElement>(null)
   const forkedRef = useForkedRef(ref, navLinkRef)
 
-  const { setVisibleGroup } = useContext(CSidebarNavContext)
+  const parentChain = useContext(CNavGroupContext)
+  const setOpenChain = useContext(CSidebarNavContext)?.setOpenChain
 
   useEffect(() => {
-    rest.active = navLinkRef.current?.classList.contains('active')
-    idx && rest.active && setVisibleGroup(idx)
-  }, [rest.active, className])
+    const element = navLinkRef.current
+
+    if (!element || !setOpenChain || parentChain.length === 0) {
+      return
+    }
+
+    let wasActive = false
+    const sync = () => {
+      const active = element.classList.contains('active')
+      if (active && !wasActive) {
+        setOpenChain(parentChain)
+      }
+
+      wasActive = active
+    }
+
+    sync()
+    const observer = new MutationObserver(sync)
+    observer.observe(element, { attributes: true, attributeFilter: ['class'] })
+
+    return () => observer.disconnect()
+  }, [parentChain, setOpenChain])
 
   return (
     <CLink className={classNames('nav-link', className)} {...rest} ref={forkedRef}>
@@ -46,7 +63,6 @@ CNavLink.propTypes = {
   children: PropTypes.node,
   className: PropTypes.string,
   disabled: PropTypes.bool,
-  idx: PropTypes.string,
 }
 
 CNavLink.displayName = 'CNavLink'

--- a/packages/coreui-react/src/components/nav/__tests__/CNavGroup.spec.tsx
+++ b/packages/coreui-react/src/components/nav/__tests__/CNavGroup.spec.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react'
 import { fireEvent, render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
-import { CNavGroup } from '../index'
-import { CSidebarNavContext } from '../../sidebar/CSidebarNavContext'
+import { CNavGroup, CNavItem } from '../index'
+import { CSidebarNav } from '../../sidebar/CSidebarNav'
 
 test('loads and displays CNavGroup component', async () => {
   const { container } = render(<CNavGroup toggler="anchorText" />)
@@ -11,43 +11,163 @@ test('loads and displays CNavGroup component', async () => {
 
 test('CNavGroup customize', async () => {
   const { container } = render(
-    <CNavGroup className="bazinga" toggler="anchorText" visible={true} idx="1" />
+    <CNavGroup className="bazinga" toggler="anchorText" visible={true} />
   )
   expect(container).toMatchSnapshot()
   expect(container.firstChild).toHaveClass('nav-group')
   expect(container.firstChild).toHaveClass('bazinga')
   const arr = container.getElementsByClassName('nav-link')
   if (arr.length > 0) {
-    //expect(arr[0].innerText).toHaveTextContent('anchorText')
     expect(arr[0].innerHTML).toBe('anchorText')
   } else {
     expect(true).toBe(false)
   }
 })
 
-test('CNavGroup stays expanded when visible prop is set', async () => {
-  render(
-    <CSidebarNavContext.Provider value={{ visibleGroup: '', setVisibleGroup: jest.fn() }}>
-      <CNavGroup idx="1" toggler="anchorText" visible={true} />
-    </CSidebarNavContext.Provider>
+test('CNavGroup toggles its own visibility when uncontrolled', async () => {
+  const { container } = render(
+    <CSidebarNav>
+      <CNavGroup toggler="anchorText">
+        <CNavItem href="#">Item</CNavItem>
+      </CNavGroup>
+    </CSidebarNav>
   )
 
-  expect(screen.getByRole('listitem')).toHaveClass('show')
+  const group = container.querySelector('.nav-group') as HTMLElement
+  expect(group).not.toHaveClass('show')
+
+  fireEvent.click(container.querySelector('.nav-group-toggle') as HTMLElement)
+  expect(group).toHaveClass('show')
+
+  fireEvent.click(container.querySelector('.nav-group-toggle') as HTMLElement)
+  expect(group).not.toHaveClass('show')
+})
+
+test('CNavGroup follows the visible prop in controlled mode', async () => {
+  const { container, rerender } = render(<CNavGroup toggler="anchorText" visible={true} />)
+  expect(container.querySelector('.nav-group')).toHaveClass('show')
+
+  rerender(<CNavGroup toggler="anchorText" visible={false} />)
+  expect(container.querySelector('.nav-group')).not.toHaveClass('show')
+})
+
+test('CNavGroup stays open when the parent rejects the collapse (controlled)', async () => {
+  const onVisibleChange = jest.fn()
+  const { container } = render(
+    <CNavGroup toggler="anchorText" visible={true} onVisibleChange={onVisibleChange} />
+  )
+
+  expect(container.querySelector('.nav-group')).toHaveClass('show')
+
+  // Parent keeps `visible` at `true` (rejects the collapse).
+  fireEvent.click(container.querySelector('.nav-group-toggle') as HTMLElement)
+
+  expect(onVisibleChange).toHaveBeenCalledWith(false)
+  expect(container.querySelector('.nav-group')).toHaveClass('show')
 })
 
 test('CNavGroup toggler render function receives visible state', async () => {
-  render(
-    <CSidebarNavContext.Provider value={{ visibleGroup: '1', setVisibleGroup: jest.fn() }}>
-      <CNavGroup
-        idx="1"
-        toggler={({ visible }) => <span>{visible ? 'expanded' : 'collapsed'}</span>}
-      />
-    </CSidebarNavContext.Provider>
-  )
+  render(<CNavGroup toggler={({ visible }) => <span>{visible ? 'expanded' : 'collapsed'}</span>} />)
 
-  expect(screen.getByText('expanded')).toBeInTheDocument()
+  expect(screen.getByText('collapsed')).toBeInTheDocument()
 
   fireEvent.click(screen.getByRole('link'))
 
-  expect(screen.getByText('collapsed')).toBeInTheDocument()
+  expect(screen.getByText('expanded')).toBeInTheDocument()
+})
+
+test('an active nav link opens its parent group', async () => {
+  const { container } = render(
+    <CSidebarNav>
+      <CNavGroup toggler="anchorText">
+        <CNavItem href="#" active>
+          Item
+        </CNavItem>
+      </CNavGroup>
+    </CSidebarNav>
+  )
+
+  expect(container.querySelector('.nav-group')).toHaveClass('show')
+})
+
+test('opening another group closes a controlled group when the parent accepts', async () => {
+  const Wrapper = () => {
+    const [visible, setVisible] = React.useState(true)
+    return (
+      <CSidebarNav>
+        <CNavGroup toggler="Controlled" visible={visible} onVisibleChange={setVisible}>
+          <CNavItem href="#">A</CNavItem>
+        </CNavGroup>
+        <CNavGroup toggler="Other">
+          <CNavItem href="#">B</CNavItem>
+        </CNavGroup>
+      </CSidebarNav>
+    )
+  }
+
+  const { container } = render(<Wrapper />)
+  const [controlled, other] = Array.from(container.querySelectorAll('.nav-group'))
+  expect(controlled).toHaveClass('show')
+
+  fireEvent.click(container.querySelectorAll('.nav-group-toggle')[1] as HTMLElement)
+
+  expect(other).toHaveClass('show')
+  expect(controlled).not.toHaveClass('show')
+})
+
+test('a locked controlled group stays open when another group opens', async () => {
+  const Wrapper = () => {
+    const [visible, setVisible] = React.useState(true)
+    const onVisibleChange = (value: boolean) => {
+      if (value) {
+        setVisible(true)
+      }
+    }
+    return (
+      <CSidebarNav>
+        <CNavGroup toggler="Locked" visible={visible} onVisibleChange={onVisibleChange}>
+          <CNavItem href="#">A</CNavItem>
+        </CNavGroup>
+        <CNavGroup toggler="Other">
+          <CNavItem href="#">B</CNavItem>
+        </CNavGroup>
+      </CSidebarNav>
+    )
+  }
+
+  const { container } = render(<Wrapper />)
+  const [locked, other] = Array.from(container.querySelectorAll('.nav-group'))
+  expect(locked).toHaveClass('show')
+
+  fireEvent.click(container.querySelectorAll('.nav-group-toggle')[1] as HTMLElement)
+
+  expect(other).toHaveClass('show')
+  expect(locked).toHaveClass('show')
+})
+
+test('nested default-open groups render open and stay independently toggleable', async () => {
+  const { container } = render(
+    <CSidebarNav>
+      <CNavGroup toggler="Group A" visible>
+        <CNavGroup toggler="Group B" visible>
+          <CNavItem href="#">Item</CNavItem>
+        </CNavGroup>
+      </CNavGroup>
+    </CSidebarNav>
+  )
+
+  const [groupA, groupB] = Array.from(container.querySelectorAll('.nav-group'))
+  expect(groupA).toHaveClass('show')
+  expect(groupB).toHaveClass('show')
+
+  // Collapsing the inner group keeps the outer one open.
+  const innerToggler = container.querySelectorAll('.nav-group-toggle')[1] as HTMLElement
+  fireEvent.click(innerToggler)
+  expect(groupA).toHaveClass('show')
+  expect(groupB).not.toHaveClass('show')
+
+  // Collapsing the outer group closes the whole branch.
+  const outerToggler = container.querySelectorAll('.nav-group-toggle')[0] as HTMLElement
+  fireEvent.click(outerToggler)
+  expect(groupA).not.toHaveClass('show')
 })

--- a/packages/coreui-react/src/components/nav/__tests__/__snapshots__/CNavGroup.spec.tsx.snap
+++ b/packages/coreui-react/src/components/nav/__tests__/__snapshots__/CNavGroup.spec.tsx.snap
@@ -6,6 +6,7 @@ exports[`CNavGroup customize 1`] = `
     class="nav-group show bazinga"
   >
     <a
+      aria-expanded="true"
       class="nav-link nav-group-toggle"
       href="#"
     >
@@ -25,6 +26,7 @@ exports[`loads and displays CNavGroup component 1`] = `
     class="nav-group"
   >
     <a
+      aria-expanded="false"
       class="nav-link nav-group-toggle"
       href="#"
     >

--- a/packages/coreui-react/src/components/sidebar/CSidebarNav.tsx
+++ b/packages/coreui-react/src/components/sidebar/CSidebarNav.tsx
@@ -1,17 +1,6 @@
-import React, {
-  ElementType,
-  forwardRef,
-  HTMLAttributes,
-  ReactElement,
-  ReactNode,
-  useState,
-} from 'react'
+import React, { ElementType, forwardRef, HTMLAttributes, useMemo, useState } from 'react'
 import PropTypes from 'prop-types'
 import classNames from 'classnames'
-
-import type { CNavGroupProps } from '../nav/CNavGroup'
-import type { CNavLinkProps } from '../nav/CNavLink'
-import type { CNavItemProps } from '../nav/CNavItem'
 
 import { CSidebarNavContext } from './CSidebarNavContext'
 
@@ -42,54 +31,15 @@ export interface CSidebarNavProps extends HTMLAttributes<HTMLUListElement> {
   variant?: 'tree'
 }
 
-const isNavElement = (
-  child: ReactNode
-): child is ReactElement<CNavGroupProps | CNavLinkProps | CNavItemProps> => {
-  if (!React.isValidElement(child)) return false
-  const type = child.type as { displayName?: string }
-  return (
-    type.displayName === 'CNavGroup' ||
-    type.displayName === 'CNavLink' ||
-    type.displayName === 'CNavItem'
-  )
-}
-
-const recursiveClone = (children: ReactNode, id?: string, updateId?: boolean): ReactNode => {
-  return React.Children.map(children, (child, index) => {
-    if (!isNavElement(child)) {
-      return child
-    }
-
-    const _id = id ? (updateId ? `${id}.${index}` : `${id}`) : `${index}`
-
-    if (child.props.children) {
-      const type = child.type as { displayName?: string }
-      const shouldUpdateId = type.displayName !== 'CNavItem'
-
-      return React.cloneElement(child, {
-        idx: _id,
-        children: recursiveClone(child.props.children, _id, shouldUpdateId),
-      })
-    }
-
-    return React.cloneElement(child, {
-      idx: _id,
-    })
-  })
-}
-
 export const CSidebarNav: PolymorphicRefForwardingComponent<'ul', CSidebarNavProps> = forwardRef<
   HTMLUListElement,
   CSidebarNavProps
 >(({ children, as: Component = 'ul', className, compact, variant, ...rest }, ref) => {
-  const [visibleGroup, setVisibleGroup] = useState('')
-  const CNavContextValues = {
-    visibleGroup,
-    setVisibleGroup,
-  }
+  const [openChain, setOpenChain] = useState<string[]>([])
+  const contextValue = useMemo(() => ({ openChain, setOpenChain }), [openChain])
 
   return (
-    <CSidebarNavContext.Provider value={CNavContextValues}>
+    <CSidebarNavContext.Provider value={contextValue}>
       <Component
         className={classNames(
           'sidebar-nav',
@@ -102,7 +52,7 @@ export const CSidebarNav: PolymorphicRefForwardingComponent<'ul', CSidebarNavPro
         ref={ref}
         {...rest}
       >
-        {recursiveClone(children)}
+        {children}
       </Component>
     </CSidebarNavContext.Provider>
   )

--- a/packages/coreui-react/src/components/sidebar/CSidebarNavContext.ts
+++ b/packages/coreui-react/src/components/sidebar/CSidebarNavContext.ts
@@ -1,8 +1,11 @@
-import { createContext } from 'react'
+import { createContext, Dispatch, SetStateAction } from 'react'
 
 export interface CSidebarNavContextProps {
-  visibleGroup: string
-  setVisibleGroup: React.Dispatch<React.SetStateAction<string | undefined>>
+  /**
+   * The chain of stable ids of the currently open nav group, from the root to the open leaf.
+   */
+  openChain: string[]
+  setOpenChain: Dispatch<SetStateAction<string[]>>
 }
 
-export const CSidebarNavContext = createContext({} as CSidebarNavContextProps)
+export const CSidebarNavContext = createContext<CSidebarNavContextProps | null>(null)

--- a/packages/docs/content/api/CNavGroup.api.mdx
+++ b/packages/docs/content/api/CNavGroup.api.mdx
@@ -45,6 +45,16 @@ import CNavGroup from '@coreui/react/src/components/nav/CNavGroup'
           <p>Make nav group more compact by cutting all <code>{`padding`}</code> in half.</p>
         </td>
       </tr>
+      <tr id="cnavgroup-on-visible-change">
+        <td className="text-primary fw-semibold">onVisibleChange<a href="#cnavgroup-on-visible-change" aria-label="CNavGroup onVisibleChange permalink" className="anchor-link after">#</a><span className="badge bg-success">5.12.0+</span></td>
+        <td>-</td>
+        <td><code>{`(visible: boolean) => void`}</code></td>
+      </tr>
+      <tr>
+        <td colSpan="3">
+          <p>Callback fired when the user toggles the group. Receives the requested visibility. In controlled mode (<code>{`visible`}</code> set), update <code>{`visible`}</code> from here—or ignore the change to keep the group as is.</p>
+        </td>
+      </tr>
       <tr id="cnavgroup-toggler">
         <td className="text-primary fw-semibold">toggler<a href="#cnavgroup-toggler" aria-label="CNavGroup toggler permalink" className="anchor-link after">#</a></td>
         <td>-</td>

--- a/packages/docs/content/components/sidebar/api.mdx
+++ b/packages/docs/content/components/sidebar/api.mdx
@@ -2,7 +2,7 @@
 title: React Sidebar Component API
 name: Sidebar API
 description: Explore the API reference for the React Sidebar component and discover how to effectively utilize its props for customization.
-route: /components/widgets/
+route: /components/sidebar/
 ---
 
 import CSidebarAPI from '../../api/CSidebar.api.mdx'

--- a/packages/docs/content/components/sidebar/examples/SidebarControlledGroupExample.tsx
+++ b/packages/docs/content/components/sidebar/examples/SidebarControlledGroupExample.tsx
@@ -1,0 +1,81 @@
+import React, { useState } from 'react'
+import { CButton, CNavGroup, CNavItem, CSidebar, CSidebarFooter, CSidebarNav } from '@coreui/react'
+
+import CIcon from '@coreui/icons-react'
+import { cilCloudDownload, cilLayers, cilPuzzle, cilSettings, cilSpeedometer } from '@coreui/icons'
+
+export const SidebarControlledGroupExample = () => {
+  const [visible, setVisible] = useState(true)
+  const [locked, setLocked] = useState(true)
+
+  const handleVisibleChange = (value: boolean) => {
+    if (!value && locked) {
+      return
+    }
+
+    setVisible(value)
+  }
+
+  return (
+    <CSidebar className="border-end">
+      <CSidebarNav>
+        <CNavItem href="#">
+          <CIcon customClassName="nav-icon" icon={cilSpeedometer} /> Dashboard
+        </CNavItem>
+        <CNavGroup
+          onVisibleChange={handleVisibleChange}
+          toggler={
+            <>
+              <CIcon customClassName="nav-icon" icon={cilPuzzle} /> Active section
+            </>
+          }
+          visible={visible}
+        >
+          <CNavItem href="#">Overview</CNavItem>
+          <CNavItem href="#">Settings</CNavItem>
+        </CNavGroup>
+        <CNavGroup
+          toggler={
+            <>
+              <CIcon customClassName="nav-icon" icon={cilLayers} /> Components
+            </>
+          }
+        >
+          <CNavItem href="#">Base</CNavItem>
+          <CNavItem href="#">Buttons</CNavItem>
+          <CNavGroup
+            toggler={
+              <>
+                <span className="nav-icon">
+                  <span className="nav-icon-bullet"></span>
+                </span>{' '}
+                Forms
+              </>
+            }
+          >
+            <CNavItem href="#">Inputs</CNavItem>
+            <CNavItem href="#">Selects</CNavItem>
+          </CNavGroup>
+        </CNavGroup>
+        <CNavGroup
+          toggler={
+            <>
+              <CIcon customClassName="nav-icon" icon={cilSettings} /> Settings
+            </>
+          }
+        >
+          <CNavItem href="#">Profile</CNavItem>
+          <CNavItem href="#">Security</CNavItem>
+        </CNavGroup>
+        <CNavItem href="https://coreui.io">
+          <CIcon customClassName="nav-icon" icon={cilCloudDownload} /> Download CoreUI
+        </CNavItem>
+      </CSidebarNav>
+      <CSidebarFooter className="border-top">
+        <CButton color="primary" size="sm" onClick={() => setLocked(!locked)}>
+          {locked ? 'Unlock collapsing' : 'Lock the active section open'}
+        </CButton>
+      </CSidebarFooter>
+    </CSidebar>
+  )
+}

--- a/packages/docs/content/components/sidebar/examples/SidebarExample.tsx
+++ b/packages/docs/content/components/sidebar/examples/SidebarExample.tsx
@@ -146,6 +146,35 @@ export const SidebarExample = () => {
             </CNavGroup>
           </CNavGroup>
         </CNavGroup>
+        <CNavGroup
+          toggler={({ visible }) => (
+            <>
+              <CIcon customClassName="nav-icon" icon={cilSettings} /> Settings group
+              <span className="nav-group-toggle-indicator">
+                <CIcon className="icon icon-sm" icon={visible ? cilMinus : cilPlus} />
+              </span>
+            </>
+          )}
+        >
+          <CNavItem href="#">Item</CNavItem>
+          <CNavItem href="#">Item</CNavItem>
+          <CNavGroup
+            toggler={({ visible }) => (
+              <>
+                <span className="nav-icon">
+                  <span className="nav-icon-bullet"></span>
+                </span>{' '}
+                Nested group
+                <span className="nav-group-toggle-indicator">
+                  <CIcon className="icon icon-sm" icon={visible ? cilMinus : cilPlus} />
+                </span>
+              </>
+            )}
+          >
+            <CNavItem href="#">Item</CNavItem>
+            <CNavItem href="#">Item</CNavItem>
+          </CNavGroup>
+        </CNavGroup>
         <CNavItem href="https://coreui.io">
           <CIcon customClassName="nav-icon" icon={cilCloudDownload} /> Download CoreUI
         </CNavItem>

--- a/packages/docs/content/components/sidebar/index.mdx
+++ b/packages/docs/content/components/sidebar/index.mdx
@@ -138,6 +138,20 @@ Use `.show` and `.hide` classes inside `.nav-group-toggle-indicator` to control 
   componentName="React Sidebar"
 />
 
+### Controlled navigation group
+
+<AddedIn version="5.12.0" />
+
+`CNavGroup` works uncontrolled by default—clicking the toggler expands and collapses it. To control it from the parent, set `visible` and handle `onVisibleChange`. In controlled mode the toggler only requests a change through `onVisibleChange`; the group follows the `visible` prop, so the parent has the final say.
+
+This makes it possible to keep a section open even when the user clicks to collapse it—useful for a route-aware sidebar that must keep the active section expanded. Toggle the lock and try to collapse the group: while locked, the parent rejects the change and the group stays open.
+
+<ExampleSnippet
+  className="bg-body-secondary p-0 rounded-bottom-0 overflow-hidden"
+  component="SidebarControlledGroupExample"
+  componentName="React Sidebar"
+/>
+
 ## Dark sidebar
 
 Change the appearance of sidebars with `colorScheme="dark"`.


### PR DESCRIPTION
## Summary

Reworks the sidebar nav group so it works either **uncontrolled** (the toggler manages its own state) or **controlled** (the parent owns `visible`), and replaces the positional `idx` / `recursiveClone` coordination with a **context-based accordion** using stable ids.

### What changes

- **`onVisibleChange` + controlled mode.** A group is controlled when `visible` and `onVisibleChange` are provided together. The toggler then only *requests* a change and the group follows the prop, so a rejected collapse keeps it open—no desync. Used on its own, `visible` still acts as the default-open state and the group stays fully toggleable (backward compatible).
- **Context-based accordion with stable `useId` chains.** Groups no longer rely on `CSidebarNav` cloning children to inject a positional dotted `idx`. Each group derives a stable id chain through React context, so coordination works through wrappers, fragments and `Children.map`, and the duplicated logic in `CSidebarNav` is gone.
- **Consistent accordion for controlled groups.** When another branch opens, a controlled group requests its own close through `onVisibleChange` (the parent decides—collapse it, or keep it open if it must stay expanded).
- **Robust active-link detection.** `CNavLink` now observes the link's `class` with a `MutationObserver`, so client-side navigation reopens the active section. The previous effect missed route changes that didn't change `className`.
- **Accessibility.** The toggler gets `aria-expanded`.

### Notes

- `CNavGroup` no longer takes the internal `idx` prop, and `CSidebarNavContext` changes shape (both were internal, not part of the public API).
- The sidebar nav is a one-open-per-level accordion; two sibling groups marked `visible` resolve to a single open branch.

### Docs

Adds a "Controlled navigation group" example to the Sidebar page and refreshes the main sidebar example.

### Tests

`CNavGroup.spec.tsx` covers uncontrolled toggling, controlled reject, accordion close on sibling open (accept vs. locked), nested default-open groups staying independently toggleable, the toggler render function, and active-link auto-open.