### PR TITLE
fix(build): bump tsconfig lib to es2023 to support Array.prototype.at()

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "outDir": "dist",
     "module": "esnext",
     "target": "es2015",
-    "lib": ["dom", "es2015", "es2016", "es2017", "es2018", "es2019", "es2020", "es2021"],
+    "lib": ["dom", "es2023"],
     "sourceMap": true,
     "allowJs": false,
     "declaration": true,


### PR DESCRIPTION
## Problem

`tsconfig.json` declared `"lib"` only up to `es2021`, but the source uses `Array.prototype.at()` (ES2022) in `CFocusTrap`. Under `ts-jest` (which type-checks) this throws `TS2550: Property 'at' does not exist on type 'HTMLElement[]'`, so the affected test suites fail to compile and `jest:test` (the project-check CI) goes red.

## Fix

Set `"lib": ["dom", "es2023"]`. `es2023` is a superset of the previously-listed `es2015…es2021` libs, so the long list collapses to one entry, and it covers the `.at()` typings the code already relies on. This only affects type-checking — emit and `target` are unchanged.

## Verification

`npx jest src/components/nav src/components/focus-trap` — all suites now compile and pass (previously `CNav.spec` failed to run).