### PR TITLE
docs(CSearchButton): change custom shortcut example to meta+i to avoid DocSearch conflict

### DIFF
--- a/packages/docs/content/components/search-button/examples/SearchButtonCustomShortcutExample.tsx
+++ b/packages/docs/content/components/search-button/examples/SearchButtonCustomShortcutExample.tsx
@@ -8,7 +8,7 @@ export const SearchButtonCustomShortcutExample = () => {
     <div>
       <CSearchButton
         placeholder="Command palette"
-        shortcut="meta+k,ctrl+k"
+        shortcut="meta+i,ctrl+i"
         onTrigger={() => setCount((value) => value + 1)}
         aria-label="Open command palette"
       />


### PR DESCRIPTION
The **Custom shortcut** Search Button example used `meta+k,ctrl+k`, which collides with the docs site's own DocSearch (it opens on <kbd>⌘K</kbd> / <kbd>Ctrl+K</kbd>) — pressing the shortcut on the page opened the docs search instead of the demo.

Switches the example to `meta+i,ctrl+i`, which avoids DocSearch (⌘K), the basic example (`meta+/`), and the offcanvas example (`meta+shift+o`).

Docs-only change (example shortcut value). Mirrored in vanilla and Vue.