### PR TITLE
fix(CDropdown): prevent window listener and popper leaks on unmount

### DIFF
--- a/packages/coreui-react/src/components/dropdown/CDropdown.tsx
+++ b/packages/coreui-react/src/components/dropdown/CDropdown.tsx
@@ -271,18 +271,14 @@ export const CDropdown: PolymorphicRefForwardingComponent<'div', CDropdownProps>
     useEffect(() => {
       if (visible) {
         handleShow()
-      } else {
+      } else if (_visible) {
         handleHide()
       }
     }, [visible])
 
     useEffect(() => {
-      return () => {
-        if (_visible) {
-          handleHide()
-        }
-      }
-    }, [])
+      return () => destroyPopper()
+    }, [destroyPopper])
 
     useEffect(() => {
       const referenceElement = getReferenceElement(reference, dropdownToggleElement, dropdownRef)
@@ -302,21 +298,12 @@ export const CDropdown: PolymorphicRefForwardingComponent<'div', CDropdownProps>
     const handleHide = useCallback(() => {
       setVisible(false)
 
-      const menuElement = dropdownMenuRef.current
-      const toggleElement = dropdownToggleElement
-
       if (allowPopperUse) {
         destroyPopper()
       }
 
-      menuElement?.removeEventListener('keydown', handleKeydown)
-      toggleElement?.removeEventListener('keydown', handleKeydown)
-
-      window.removeEventListener('click', handleClick)
-      window.removeEventListener('keyup', handleKeyup)
-
       onHide?.()
-    }, [allowPopperUse, dropdownToggleElement, destroyPopper, onHide])
+    }, [allowPopperUse, destroyPopper, onHide])
 
     const handleKeydown = useCallback((event: KeyboardEvent) => {
       if (!dropdownMenuRef.current) {
@@ -399,11 +386,6 @@ export const CDropdown: PolymorphicRefForwardingComponent<'div', CDropdownProps>
           }
 
           toggleElement.focus()
-          toggleElement.addEventListener('keydown', handleKeydown)
-          menuElement.addEventListener('keydown', handleKeydown)
-
-          window.addEventListener('click', handleClick)
-          window.addEventListener('keyup', handleKeyup)
 
           if (event && (event.key === 'ArrowDown' || event.key === 'ArrowUp')) {
             setPendingKeyDownEvent(event)
@@ -412,18 +394,31 @@ export const CDropdown: PolymorphicRefForwardingComponent<'div', CDropdownProps>
           onShow?.()
         }
       },
-      [
-        allowPopperUse,
-        computedPopperConfig,
-        dropdownToggleElement,
-        reference,
-        handleClick,
-        handleKeydown,
-        handleKeyup,
-        initPopper,
-        onShow,
-      ]
+      [allowPopperUse, computedPopperConfig, dropdownToggleElement, reference, initPopper, onShow]
     )
+
+    useEffect(() => {
+      if (!_visible) {
+        return
+      }
+
+      const menuElement = dropdownMenuRef.current
+      const toggleElement = dropdownToggleElement
+
+      toggleElement?.addEventListener('keydown', handleKeydown)
+      menuElement?.addEventListener('keydown', handleKeydown)
+
+      window.addEventListener('click', handleClick)
+      window.addEventListener('keyup', handleKeyup)
+
+      return () => {
+        toggleElement?.removeEventListener('keydown', handleKeydown)
+        menuElement?.removeEventListener('keydown', handleKeydown)
+
+        window.removeEventListener('click', handleClick)
+        window.removeEventListener('keyup', handleKeyup)
+      }
+    }, [_visible, dropdownToggleElement, handleClick, handleKeydown, handleKeyup])
 
     const contextValues = useMemo(
       () => ({

--- a/packages/coreui-react/src/components/dropdown/__tests__/CDropdown.spec.tsx
+++ b/packages/coreui-react/src/components/dropdown/__tests__/CDropdown.spec.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import '@testing-library/jest-dom'
+import { createPopper } from '@popperjs/core'
 import {
   CDropdown,
   CDropdownToggle,
@@ -10,6 +11,14 @@ import {
   CDropdownHeader,
   CDropdownDivider,
 } from '../index'
+
+jest.mock('@popperjs/core', () => {
+  const actual = jest.requireActual('@popperjs/core')
+  return {
+    ...actual,
+    createPopper: jest.fn(actual.createPopper),
+  }
+})
 
 test('loads and displays CDropdown component', async () => {
   const { container } = render(<CDropdown>Test</CDropdown>)
@@ -95,6 +104,52 @@ test('CDropdown opens on toggle click and closes on clicking outside', async () 
   await waitFor(() => {
     const closedMenu = screen.getByRole('menu', { hidden: true }) // Adjust role if different
     expect(closedMenu).not.toHaveClass('show')
+  })
+})
+
+test('CDropdown keeps absolute positioning attached to a replaced toggler', async () => {
+  const createPopperMock = createPopper as jest.Mock
+  createPopperMock.mockClear()
+
+  const DropdownApp = ({ togglerKey }: { togglerKey: string }) => (
+    <CDropdown>
+      <CDropdownToggle key={togglerKey} data-testid={`toggler-${togglerKey}`}>
+        Toggle
+      </CDropdownToggle>
+      <CDropdownMenu>
+        <CDropdownItem>A</CDropdownItem>
+      </CDropdownMenu>
+    </CDropdown>
+  )
+
+  const { rerender } = render(<DropdownApp togglerKey="first" />)
+
+  fireEvent.click(screen.getByTestId('toggler-first'))
+
+  const menu = screen.getByRole('menu')
+  await waitFor(() => {
+    expect(menu).toHaveStyle('position: absolute')
+    expect(menu).toHaveAttribute('data-popper-placement', 'bottom-start')
+  })
+
+  expect(createPopperMock).toHaveBeenCalledTimes(1)
+  expect(createPopperMock.mock.calls[0][0]).toBe(screen.getByTestId('toggler-first'))
+
+  const firstPopper = createPopperMock.mock.results[0].value
+  const destroySpy = jest.spyOn(firstPopper, 'destroy')
+
+  rerender(<DropdownApp togglerKey="second" />)
+
+  await waitFor(() => {
+    expect(createPopperMock).toHaveBeenCalledTimes(2)
+  })
+
+  expect(destroySpy).toHaveBeenCalledTimes(1)
+  expect(createPopperMock.mock.calls[1][0]).toBe(screen.getByTestId('toggler-second'))
+
+  await waitFor(() => {
+    expect(menu).toHaveStyle('position: absolute')
+    expect(menu).toHaveAttribute('data-popper-placement', 'bottom-start')
   })
 })
 

--- a/packages/coreui-react/src/hooks/usePopper.ts
+++ b/packages/coreui-react/src/hooks/usePopper.ts
@@ -1,4 +1,4 @@
-import { useRef } from 'react'
+import { useCallback, useRef } from 'react'
 import { createPopper } from '@popperjs/core'
 import type { Instance, Options } from '@popperjs/core'
 
@@ -13,12 +13,16 @@ export const usePopper = (): UsePopperOutput => {
   const _popper = useRef<Instance>(undefined)
   const el = useRef<HTMLElement>(null)
 
-  const initPopper = (reference: HTMLElement, popper: HTMLElement, options: Partial<Options>) => {
-    _popper.current = createPopper(reference, popper, options)
-    el.current = popper
-  }
+  const initPopper = useCallback(
+    (reference: HTMLElement, popper: HTMLElement, options: Partial<Options>) => {
+      _popper.current?.destroy()
+      _popper.current = createPopper(reference, popper, options)
+      el.current = popper
+    },
+    []
+  )
 
-  const destroyPopper = () => {
+  const destroyPopper = useCallback(() => {
     const popperInstance = _popper.current
 
     if (popperInstance && el.current) {
@@ -26,9 +30,9 @@ export const usePopper = (): UsePopperOutput => {
     }
 
     _popper.current = undefined
-  }
+  }, [])
 
-  const updatePopper = (options?: Partial<Options>) => {
+  const updatePopper = useCallback((options?: Partial<Options>) => {
     const popperInstance = _popper.current
 
     if (popperInstance && options) {
@@ -38,7 +42,7 @@ export const usePopper = (): UsePopperOutput => {
     if (popperInstance) {
       popperInstance.update()
     }
-  }
+  }, [])
 
   return {
     popper: _popper.current,


### PR DESCRIPTION
## Problem

1. **Window listener leak on unmount.** The unmount cleanup effect captured the initial `_visible` value in a stale closure (`useEffect(() => () => { if (_visible) handleHide() }, [])`), so it never ran for a dropdown that was opened after mount. Unmounting an open dropdown left `click`/`keyup` listeners on `window` and a live Popper instance.
2. **Listener reference mismatch.** Listeners were added imperatively in `handleShow` and removed in `handleHide`. When any `useCallback` dependency changed while the dropdown was open (e.g. a new `onHide` prop or a replaced toggler element), `removeEventListener` received a different function reference and the original listener stayed attached forever.
3. **Spurious `onHide` on mount.** The `[visible]` sync effect ran `handleHide()` on first render with the default `visible={false}`, firing the `onHide` callback for a dropdown that was never opened.
4. **Popper instance leak on re-init.** `initPopper` overwrote `_popper.current` without destroying the previous instance, leaking its scroll/resize listeners whenever the toggler element was replaced while open.

## Changes

- Move keydown/click/keyup listener management to a declarative effect keyed on `_visible` (the same pattern `CModal` already uses). React guarantees the cleanup removes exactly the references that were added, including on unmount and when the toggler element changes mid-open.
- Replace the broken unmount effect with one that destroys the Popper instance.
- Guard the `[visible]` sync effect so `handleHide` only runs when the dropdown is actually open.
- Memoize `usePopper` callbacks (`useCallback`) — they only touch refs, so stable identities are safe; this stops `handleHide`/context value churn on every parent render.
- Destroy the previous Popper instance inside `initPopper` before creating a new one.

## Tests

- New regression test: replaces the toggler element (via `key`) while the dropdown is open and asserts the menu keeps `position: absolute` + `data-popper-placement`, Popper is re-created against the new toggler node, and the old instance is destroyed. Verified it fails against the previous `usePopper`.
- Full suite: 127 suites / 349 tests green, no snapshot changes (markup untouched).

Note: the `react-hooks/refs` lint error on `usePopper`'s `popper: _popper.current` return pre-exists on `main` and is left out of scope — fixing it changes the hook's public API.