### PR TITLE
fix(CTooltip,CPopover): cancel pending delay timers and preserve child handlers

### DIFF
--- a/packages/coreui-react/src/components/popover/CPopover.tsx
+++ b/packages/coreui-react/src/components/popover/CPopover.tsx
@@ -182,6 +182,14 @@ export const CPopover = forwardRef<HTMLDivElement, CPopoverProps>(
     const { initPopper, destroyPopper } = usePopper()
 
     const _delay = typeof delay === 'number' ? { show: delay, hide: delay } : delay
+    const timer = useRef<ReturnType<typeof setTimeout>>(undefined)
+
+    const clearTimer = () => {
+      if (timer.current) {
+        clearTimeout(timer.current)
+        timer.current = undefined
+      }
+    }
 
     const defaultPopperConfig: Partial<Options> = {
       modifiers: [
@@ -198,12 +206,23 @@ export const CPopover = forwardRef<HTMLDivElement, CPopoverProps>(
     }
 
     const handleShow = () => {
-      setMounted(true)
+      clearTimer()
+
+      if (mounted) {
+        timer.current = setTimeout(() => {
+          setVisible(true)
+        }, _delay.show)
+      } else {
+        setMounted(true)
+      }
+
       onShow?.()
     }
 
     const handleHide = () => {
-      setTimeout(() => {
+      clearTimer()
+
+      timer.current = setTimeout(() => {
         setVisible(false)
         onHide?.()
       }, _delay.hide)
@@ -220,7 +239,7 @@ export const CPopover = forwardRef<HTMLDivElement, CPopoverProps>(
     useEffect(() => {
       if (mounted && togglerRef.current && popoverRef.current) {
         initPopper(togglerRef.current, popoverRef.current, computedPopperConfig)
-        setTimeout(() => {
+        timer.current = setTimeout(() => {
           setVisible(true)
         }, _delay.show)
 
@@ -233,6 +252,13 @@ export const CPopover = forwardRef<HTMLDivElement, CPopoverProps>(
     }, [mounted])
 
     useEffect(() => {
+      return () => {
+        clearTimer()
+        destroyPopper()
+      }
+    }, [])
+
+    useEffect(() => {
       if (!_visible && togglerRef.current && popoverRef.current) {
         executeAfterTransition(() => {
           setMounted(false)
@@ -240,23 +266,47 @@ export const CPopover = forwardRef<HTMLDivElement, CPopoverProps>(
       }
     }, [_visible])
 
+    const child = children as React.ReactElement<
+      React.HTMLAttributes<HTMLElement> & { ref?: React.Ref<HTMLElement> }
+    >
+
     return (
       <>
-        {React.cloneElement(children as React.ReactElement<any>, {
+        {React.cloneElement(child, {
           ...(_visible && {
             'aria-describedby': id,
           }),
           ref: togglerRef,
           ...((trigger === 'click' || trigger.includes('click')) && {
-            onClick: () => (_visible ? handleHide() : handleShow()),
+            onClick: (event: React.MouseEvent<HTMLElement>) => {
+              child.props.onClick?.(event)
+
+              if (_visible) {
+                handleHide()
+              } else {
+                handleShow()
+              }
+            },
           }),
           ...((trigger === 'focus' || trigger.includes('focus')) && {
-            onFocus: () => handleShow(),
-            onBlur: () => handleHide(),
+            onFocus: (event: React.FocusEvent<HTMLElement>) => {
+              child.props.onFocus?.(event)
+              handleShow()
+            },
+            onBlur: (event: React.FocusEvent<HTMLElement>) => {
+              child.props.onBlur?.(event)
+              handleHide()
+            },
           }),
           ...((trigger === 'hover' || trigger.includes('hover')) && {
-            onMouseEnter: () => handleShow(),
-            onMouseLeave: () => handleHide(),
+            onMouseEnter: (event: React.MouseEvent<HTMLElement>) => {
+              child.props.onMouseEnter?.(event)
+              handleShow()
+            },
+            onMouseLeave: (event: React.MouseEvent<HTMLElement>) => {
+              child.props.onMouseLeave?.(event)
+              handleHide()
+            },
           }),
         })}
         <CConditionalPortal container={container} portal={true}>

--- a/packages/coreui-react/src/components/popover/__tests__/CPopover.spec.tsx
+++ b/packages/coreui-react/src/components/popover/__tests__/CPopover.spec.tsx
@@ -16,6 +16,74 @@ afterEach(() => {
   cleanup()
 })
 
+test('CPopover stays visible when re-hovered during the hide delay', async () => {
+  jest.useFakeTimers()
+
+  render(
+    <CPopover trigger="hover" delay={{ show: 0, hide: 300 }} content="content">
+      <CButton color="primary">Test</CButton>
+    </CPopover>
+  )
+
+  const btn = screen.getByRole('button', { name: /test/i })
+
+  act(() => {
+    fireEvent.mouseOver(btn)
+  })
+
+  act(() => {
+    jest.runAllTimers()
+  })
+
+  expect(document.querySelector('.popover')).toHaveClass('show')
+
+  act(() => {
+    fireEvent.mouseOut(btn)
+    jest.advanceTimersByTime(100)
+  })
+
+  act(() => {
+    fireEvent.mouseOver(btn)
+    jest.advanceTimersByTime(1000)
+  })
+
+  expect(document.querySelector('.popover')).toHaveClass('show')
+
+  jest.useRealTimers()
+})
+
+test('CPopover preserves event handlers of the child element', async () => {
+  jest.useFakeTimers()
+
+  const onClick = jest.fn()
+  const onMouseEnter = jest.fn()
+
+  render(
+    <CPopover trigger={['hover', 'click']} content="content">
+      <CButton color="primary" onClick={onClick} onMouseEnter={onMouseEnter}>
+        Test
+      </CButton>
+    </CPopover>
+  )
+
+  const btn = screen.getByRole('button', { name: /test/i })
+
+  act(() => {
+    fireEvent.mouseOver(btn)
+    jest.runAllTimers()
+  })
+
+  act(() => {
+    fireEvent.click(btn)
+    jest.runAllTimers()
+  })
+
+  expect(onMouseEnter).toHaveBeenCalledTimes(1)
+  expect(onClick).toHaveBeenCalledTimes(1)
+
+  jest.useRealTimers()
+})
+
 test('loads and displays CPopover component', async () => {
   const { container } = render(
     <CPopover content="A">

--- a/packages/coreui-react/src/components/tooltip/CTooltip.tsx
+++ b/packages/coreui-react/src/components/tooltip/CTooltip.tsx
@@ -173,6 +173,14 @@ export const CTooltip = forwardRef<HTMLDivElement, CTooltipProps>(
     const { initPopper, destroyPopper, updatePopper } = usePopper()
 
     const _delay = typeof delay === 'number' ? { show: delay, hide: delay } : delay
+    const timer = useRef<ReturnType<typeof setTimeout>>(undefined)
+
+    const clearTimer = () => {
+      if (timer.current) {
+        clearTimeout(timer.current)
+        timer.current = undefined
+      }
+    }
 
     const defaultPopperConfig: Partial<Options> = {
       modifiers: [
@@ -189,12 +197,23 @@ export const CTooltip = forwardRef<HTMLDivElement, CTooltipProps>(
     }
 
     const handleShow = () => {
-      setMounted(true)
+      clearTimer()
+
+      if (mounted) {
+        timer.current = setTimeout(() => {
+          setVisible(true)
+        }, _delay.show)
+      } else {
+        setMounted(true)
+      }
+
       onShow?.()
     }
 
     const handleHide = () => {
-      setTimeout(() => {
+      clearTimer()
+
+      timer.current = setTimeout(() => {
         setVisible(false)
         onHide?.()
       }, _delay.hide)
@@ -211,7 +230,7 @@ export const CTooltip = forwardRef<HTMLDivElement, CTooltipProps>(
     useEffect(() => {
       if (mounted && togglerRef.current && tooltipRef.current) {
         initPopper(togglerRef.current, tooltipRef.current, computedPopperConfig)
-        setTimeout(() => {
+        timer.current = setTimeout(() => {
           setVisible(true)
         }, _delay.show)
 
@@ -222,6 +241,13 @@ export const CTooltip = forwardRef<HTMLDivElement, CTooltipProps>(
         destroyPopper()
       }
     }, [mounted])
+
+    useEffect(() => {
+      return () => {
+        clearTimer()
+        destroyPopper()
+      }
+    }, [])
 
     useEffect(() => {
       if (!_visible && togglerRef.current && tooltipRef.current) {
@@ -235,23 +261,47 @@ export const CTooltip = forwardRef<HTMLDivElement, CTooltipProps>(
       updatePopper()
     }, [content])
 
+    const child = children as React.ReactElement<
+      React.HTMLAttributes<HTMLElement> & { ref?: React.Ref<HTMLElement> }
+    >
+
     return (
       <>
-        {React.cloneElement(children as React.ReactElement<any>, {
+        {React.cloneElement(child, {
           ...(_visible && {
             'aria-describedby': id,
           }),
           ref: togglerRef,
           ...((trigger === 'click' || trigger.includes('click')) && {
-            onClick: () => (_visible ? handleHide() : handleShow()),
+            onClick: (event: React.MouseEvent<HTMLElement>) => {
+              child.props.onClick?.(event)
+
+              if (_visible) {
+                handleHide()
+              } else {
+                handleShow()
+              }
+            },
           }),
           ...((trigger === 'focus' || trigger.includes('focus')) && {
-            onFocus: () => handleShow(),
-            onBlur: () => handleHide(),
+            onFocus: (event: React.FocusEvent<HTMLElement>) => {
+              child.props.onFocus?.(event)
+              handleShow()
+            },
+            onBlur: (event: React.FocusEvent<HTMLElement>) => {
+              child.props.onBlur?.(event)
+              handleHide()
+            },
           }),
           ...((trigger === 'hover' || trigger.includes('hover')) && {
-            onMouseEnter: () => handleShow(),
-            onMouseLeave: () => handleHide(),
+            onMouseEnter: (event: React.MouseEvent<HTMLElement>) => {
+              child.props.onMouseEnter?.(event)
+              handleShow()
+            },
+            onMouseLeave: (event: React.MouseEvent<HTMLElement>) => {
+              child.props.onMouseLeave?.(event)
+              handleHide()
+            },
           }),
         })}
         <CConditionalPortal container={container} portal={true}>

--- a/packages/coreui-react/src/components/tooltip/__tests__/CTooltip.spec.tsx
+++ b/packages/coreui-react/src/components/tooltip/__tests__/CTooltip.spec.tsx
@@ -47,6 +47,101 @@ test('CTooltip customize', async () => {
   jest.useRealTimers()
 })
 
+test('CTooltip stays visible when re-hovered during the hide delay', async () => {
+  jest.useFakeTimers()
+
+  render(
+    <CTooltip trigger="hover" delay={{ show: 0, hide: 300 }} content="content">
+      <CLink>Test</CLink>
+    </CTooltip>
+  )
+
+  const link = screen.getByText('Test')
+
+  act(() => {
+    fireEvent.mouseOver(link)
+  })
+
+  act(() => {
+    jest.runAllTimers()
+  })
+
+  expect(document.querySelector('.tooltip')).toHaveClass('show')
+
+  act(() => {
+    fireEvent.mouseOut(link)
+    jest.advanceTimersByTime(100)
+  })
+
+  act(() => {
+    fireEvent.mouseOver(link)
+    jest.advanceTimersByTime(1000)
+  })
+
+  expect(document.querySelector('.tooltip')).toHaveClass('show')
+
+  jest.useRealTimers()
+})
+
+test('CTooltip cancels the pending show timer when pointer leaves before the show delay', async () => {
+  jest.useFakeTimers()
+
+  render(
+    <CTooltip trigger="hover" delay={{ show: 300, hide: 0 }} content="content">
+      <CLink>Test</CLink>
+    </CTooltip>
+  )
+
+  const link = screen.getByText('Test')
+
+  act(() => {
+    fireEvent.mouseOver(link)
+    jest.advanceTimersByTime(100)
+  })
+
+  act(() => {
+    fireEvent.mouseOut(link)
+    jest.advanceTimersByTime(1000)
+  })
+
+  expect(document.querySelector('.tooltip.show')).toBeNull()
+  expect(link).not.toHaveAttribute('aria-describedby')
+
+  jest.useRealTimers()
+})
+
+test('CTooltip preserves event handlers of the child element', async () => {
+  jest.useFakeTimers()
+
+  const onClick = jest.fn()
+  const onMouseEnter = jest.fn()
+
+  render(
+    <CTooltip trigger={['hover', 'click']} content="content">
+      <CButton onClick={onClick} onMouseEnter={onMouseEnter}>
+        Test
+      </CButton>
+    </CTooltip>
+  )
+
+  const btn = screen.getByRole('button', { name: /test/i })
+
+  act(() => {
+    fireEvent.mouseOver(btn)
+    jest.runAllTimers()
+  })
+
+  act(() => {
+    fireEvent.click(btn)
+    jest.runAllTimers()
+  })
+
+  expect(onMouseEnter).toHaveBeenCalledTimes(1)
+  expect(onClick).toHaveBeenCalledTimes(1)
+
+  jest.useRealTimers()
+})
+
 test('CTooltip onShow and onHide', async () => {
   jest.useFakeTimers()
 


### PR DESCRIPTION
## Problem

1. **Delay timer race.** `handleHide` scheduled a `setTimeout` that was never cancelled. Re-hovering the toggler during the `delay.hide` window still dismissed a visible tooltip/popover under the cursor. Symmetrically, the show timer kept running after the pointer left, flipping internal `_visible` state (and `aria-describedby` on the toggler) for a tooltip that was no longer mounted.
2. **No cleanup on unmount.** Pending timers fired after unmount and the Popper instance was never destroyed.
3. **Child handlers overridden.** `cloneElement` replaced the child's own `onClick`/`onFocus`/`onBlur`/`onMouseEnter`/`onMouseLeave` instead of composing them — a silent, hard-to-diagnose bug for consumers.

## Changes

- Track the show/hide timeout in a shared ref and clear it on every show/hide transition (the same single-timer approach Bootstrap uses).
- On re-show while still mounted, schedule the show timer directly since the `[mounted]` effect won't re-fire.
- Clear the pending timer and destroy the Popper instance on unmount.
- Call the cloned child's original event handlers before the tooltip/popover trigger logic; typed the cloned child as `ReactElement<HTMLAttributes<HTMLElement>>` instead of `any` (also clears a pre-existing `no-explicit-any` lint error on these lines).

## Tests

5 new regression tests (3 tooltip, 2 popover): re-hover during hide delay keeps it visible, leaving before the show delay cancels the pending show (incl. no stray `aria-describedby`), and child handlers still fire. All 5 fail against `main`, pass with the fix. Full suite: 127 suites / 353 tests green, no snapshot changes.