### PR TITLE
fix(CModal): fire onClosePrevented only on prevented close and ignore drag-out releases

### DIFF
--- a/packages/coreui-react/src/components/modal/CModal.tsx
+++ b/packages/coreui-react/src/components/modal/CModal.tsx
@@ -120,6 +120,7 @@ export const CModal = forwardRef<HTMLDivElement, CModalProps>(
     ref
   ) => {
     const modalRef = useRef<HTMLDivElement>(null)
+    const mouseDownTarget = useRef<EventTarget | null>(null)
     const forkedRef = useForkedRef(ref, modalRef)
 
     const [_visible, setVisible] = useState(visible)
@@ -136,11 +137,13 @@ export const CModal = forwardRef<HTMLDivElement, CModalProps>(
 
     useEffect(() => {
       if (_visible) {
+        document.addEventListener('mousedown', handleMouseDown)
         document.addEventListener('mouseup', handleClickOutside)
         document.addEventListener('keydown', handleKeyDown)
       }
 
       return () => {
+        document.removeEventListener('mousedown', handleMouseDown)
         document.removeEventListener('mouseup', handleClickOutside)
         document.removeEventListener('keydown', handleKeyDown)
       }
@@ -155,8 +158,14 @@ export const CModal = forwardRef<HTMLDivElement, CModalProps>(
     }
 
     useLayoutEffect(() => {
+      if (!staticBackdrop) {
+        return
+      }
+
       onClosePrevented?.()
-      setTimeout(() => setStaticBackdrop(false), duration)
+      const timeout = setTimeout(() => setStaticBackdrop(false), duration)
+
+      return () => clearTimeout(timeout)
     }, [staticBackdrop])
 
     // Set focus to modal after open
@@ -186,8 +195,16 @@ export const CModal = forwardRef<HTMLDivElement, CModalProps>(
       }
     }, [_visible])
 
+    const handleMouseDown = (event: Event) => {
+      mouseDownTarget.current = event.target
+    }
+
     const handleClickOutside = (event: Event) => {
-      if (modalRef.current && modalRef.current == event.target) {
+      if (
+        modalRef.current &&
+        modalRef.current == event.target &&
+        mouseDownTarget.current == event.target
+      ) {
         handleDismiss()
       }
     }

--- a/packages/coreui-react/src/components/modal/__tests__/CModal.spec.tsx
+++ b/packages/coreui-react/src/components/modal/__tests__/CModal.spec.tsx
@@ -48,6 +48,49 @@ test('CModal dialog close on press ESC', async () => {
   }
 })
 
+test('CModal calls onClosePrevented only when closing is actually prevented', async () => {
+  const onClosePrevented = jest.fn()
+
+  render(
+    <CModal backdrop="static" onClosePrevented={onClosePrevented} portal={false} visible>
+      Test
+    </CModal>
+  )
+
+  expect(onClosePrevented).toHaveBeenCalledTimes(0)
+
+  const modal = screen.getByText('Test').closest('.modal') as HTMLElement
+  fireEvent.keyDown(modal, { key: 'Escape' })
+
+  await waitFor(() => {
+    expect(onClosePrevented).toHaveBeenCalledTimes(1)
+    expect(modal).toHaveClass('modal-static')
+  })
+})
+
+test('CModal does not close when a press started inside the dialog is released over the backdrop area', async () => {
+  const onClose = jest.fn()
+
+  render(
+    <CModal onClose={onClose} portal={false} visible>
+      <div data-testid="content">Test</div>
+    </CModal>
+  )
+
+  const modal = screen.getByText('Test').closest('.modal') as HTMLElement
+  const content = screen.getByTestId('content')
+
+  fireEvent.mouseDown(content)
+  fireEvent.mouseUp(modal)
+  expect(onClose).toHaveBeenCalledTimes(0)
+
+  fireEvent.mouseDown(modal)
+  fireEvent.mouseUp(modal)
+  await waitFor(() => {
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})
+
 // test('CModal dialog closes when clicking outside the modal', async () => {
 //   const onClose = jest.fn()
 


### PR DESCRIPTION
## Problem

1. **`onClosePrevented` fired on mount.** The `useLayoutEffect` keyed on `staticBackdrop` ran on first render (and again on the `true → false` reset), so the callback fired for a modal that never had a close attempt prevented. The `modal-static` reset timeout was also never cleared, so it could fire after unmount.
2. **Modal closed when releasing a text selection over the backdrop.** Dismissal was keyed on `mouseup` target alone — selecting text inside the dialog and releasing the pointer over the `.modal` wrapper dismissed the modal. Bootstrap 5 tracks the originating `mousedown` for exactly this reason.

## Changes

- Guard the static-backdrop effect with `if (!staticBackdrop) return`, and clear the reset timeout in the effect cleanup.
- Track the `mousedown` target in a ref (listener registered alongside the existing `mouseup`/`keydown` ones) and dismiss only when both press and release target the modal wrapper.

## Tests

2 new regression tests: `onClosePrevented` stays at 0 on mount and fires once after ESC with `backdrop="static"` (incl. `modal-static` class), and a press started inside the dialog released over the wrapper does not dismiss while a full press+release on the wrapper does. Both fail against `main`, pass with the fix. Full suite: 127 suites / 350 tests green, no snapshot changes.