### PR TITLE
fix(CCarousel): clear cycle timeouts reliably and scope effects

### DIFF
--- a/packages/coreui-react/src/components/carousel/CCarousel.tsx
+++ b/packages/coreui-react/src/components/carousel/CCarousel.tsx
@@ -106,7 +106,7 @@ export const CCarousel = forwardRef<HTMLDivElement, CCarouselProps>(
 
     useEffect(() => {
       setItemsNumber(Children.toArray(children).length)
-    })
+    }, [children])
 
     useEffect(() => {
       visible && cycle()
@@ -124,10 +124,21 @@ export const CCarousel = forwardRef<HTMLDivElement, CCarouselProps>(
       return () => {
         window.removeEventListener('scroll', handleScroll)
       }
-    })
+    }, [])
+
+    useEffect(() => {
+      return () => clearCycleTimeout()
+    }, [])
+
+    const clearCycleTimeout = () => {
+      if (data.timeout) {
+        clearTimeout(data.timeout)
+        data.timeout = null
+      }
+    }
 
     const cycle = () => {
-      _pause()
+      clearCycleTimeout()
       if (!wrap && active === itemsNumber - 1) {
         return
       }
@@ -139,7 +150,7 @@ export const CCarousel = forwardRef<HTMLDivElement, CCarouselProps>(
         )
       }
     }
-    const _pause = () => pause && data.timeout && clearTimeout(data.timeout)
+    const _pause = () => pause && clearCycleTimeout()
 
     const nextItemWhenVisible = () => {
       // Don't call next when the page isn't visible

--- a/packages/coreui-react/src/components/carousel/__tests__/CCarousel.spec.tsx
+++ b/packages/coreui-react/src/components/carousel/__tests__/CCarousel.spec.tsx
@@ -59,6 +59,49 @@ test('loads and displays CCarousel component', async () => {
   expect(container).toMatchSnapshot()
 })
 
+test('CCarousel does not stack cycle timeouts when pause is disabled', async () => {
+  jest.useFakeTimers()
+
+  render(
+    <CCarousel interval={1000} pause={false}>
+      <CCarouselItem>Item-1</CCarouselItem>
+      <CCarouselItem>Item-2</CCarouselItem>
+      <CCarouselItem>Item-3</CCarouselItem>
+    </CCarousel>
+  )
+
+  const carousel = document.querySelector('.carousel') as HTMLElement
+  const baseTimerCount = jest.getTimerCount()
+
+  fireEvent.mouseLeave(carousel)
+  fireEvent.mouseLeave(carousel)
+  fireEvent.mouseLeave(carousel)
+
+  expect(jest.getTimerCount()).toBe(baseTimerCount)
+
+  jest.useRealTimers()
+})
+
+test('CCarousel clears the pending cycle timeout on unmount', async () => {
+  jest.useFakeTimers()
+
+  const { unmount } = render(
+    <CCarousel interval={1000}>
+      <CCarouselItem>Item-1</CCarouselItem>
+      <CCarouselItem>Item-2</CCarouselItem>
+    </CCarousel>
+  )
+
+  const baseTimerCount = jest.getTimerCount()
+  expect(baseTimerCount).toBeGreaterThan(0)
+
+  unmount()
+
+  expect(jest.getTimerCount()).toBe(baseTimerCount - 1)
+
+  jest.useRealTimers()
+})
+
 test('CCarousel click on indicator', async () => {
   const { container } = render(
     <CCarousel controls indicators>


### PR DESCRIPTION
## Problem

1. **Stacked timeouts with `pause={false}`.** `cycle()` relied on `_pause()` to clear the previous timeout, but `_pause` is gated on the `pause` prop — with `pause={false}` every `cycle()` call (mouse leave, slide change) scheduled an additional timeout without clearing the previous one.
2. **No cleanup on unmount.** The pending cycle timeout kept running after unmount and called `setActive` on an unmounted component.
3. **Unscoped effects.** The items-count effect and the scroll listener effect had no dependency array, so the count was recomputed and the `window` scroll listener was removed/re-added on every render.

## Changes

- Extract `clearCycleTimeout()` and call it unconditionally at the start of `cycle()`; `_pause` keeps its prop-gated semantics for hover.
- Clear the pending timeout in an unmount cleanup effect.
- Scope the items-count effect to `[children]` and register the scroll listener once (`[]` — the handler only touches refs and state setters).

## Tests

2 new regression tests using `jest.getTimerCount()`: repeated mouse-leave with `pause={false}` does not grow the pending timer count, and unmount releases the pending cycle timeout. Both fail against `main`, pass with the fix. Full suite: 127 suites / 350 tests green, no snapshot changes.