### PR TITLE
refactor(lint): replace expression statements with explicit conditionals

### DIFF
--- a/packages/coreui-react/src/components/carousel/CCarousel.tsx
+++ b/packages/coreui-react/src/components/carousel/CCarousel.tsx
@@ -109,13 +109,18 @@ export const CCarousel = forwardRef<HTMLDivElement, CCarouselProps>(
     }, [children])
 
     useEffect(() => {
-      visible && cycle()
+      if (visible) {
+        cycle()
+      }
     }, [visible])
 
     useEffect(() => {
-      !animating && cycle()
-      !animating && onSlid && onSlid(active, direction)
-      animating && onSlide && onSlide(active, direction)
+      if (animating) {
+        onSlide?.(active, direction)
+      } else {
+        cycle()
+        onSlid?.(active, direction)
+      }
     }, [animating])
 
     useEffect(() => {
@@ -169,9 +174,9 @@ export const CCarousel = forwardRef<HTMLDivElement, CCarouselProps>(
       }
       setDirection(direction)
       if (direction === 'next') {
-        active === itemsNumber - 1 ? setActive(0) : setActive(active + 1)
+        setActive(active === itemsNumber - 1 ? 0 : active + 1)
       } else {
-        active === 0 ? setActive(itemsNumber - 1) : setActive(active - 1)
+        setActive(active === 0 ? itemsNumber - 1 : active - 1)
       }
     }
 
@@ -255,7 +260,9 @@ export const CCarousel = forwardRef<HTMLDivElement, CCarouselProps>(
                   <button
                     key={`indicator${index}`}
                     onClick={() => {
-                      !animating && handleIndicatorClick(index)
+                      if (!animating) {
+                        handleIndicatorClick(index)
+                      }
                     }}
                     className={classNames({
                       active: active === index,

--- a/packages/coreui-react/src/components/carousel/__tests__/CCarousel.spec.tsx
+++ b/packages/coreui-react/src/components/carousel/__tests__/CCarousel.spec.tsx
@@ -129,7 +129,7 @@ test('CCarousel click on indicator', async () => {
 
   // click
   const ci = document.querySelector('.carousel-indicators')
-  ci && fireEvent.click(ci.children[1])
+  fireEvent.click(ci!.children[1])
   fireEvent.transitionEnd(item1)
   fireEvent.transitionEnd(item2)
 
@@ -137,7 +137,7 @@ test('CCarousel click on indicator', async () => {
   expect(item2).toHaveClass('active')
 
   // goback-click
-  ci && fireEvent.click(ci.children[0])
+  fireEvent.click(ci!.children[0])
   fireEvent.transitionEnd(item1)
   fireEvent.transitionEnd(item2)
 
@@ -173,7 +173,7 @@ test('CCarousel click on button', async () => {
 
   // click
   const buttonNext = document.querySelector('.carousel-control-next')
-  buttonNext && fireEvent.click(buttonNext)
+  fireEvent.click(buttonNext!)
   fireEvent.transitionEnd(item1)
   fireEvent.transitionEnd(item2)
 
@@ -182,7 +182,7 @@ test('CCarousel click on button', async () => {
 
   // goback-click
   const buttonPrev = document.querySelector('.carousel-control-prev')
-  buttonPrev && fireEvent.click(buttonPrev)
+  fireEvent.click(buttonPrev!)
   fireEvent.transitionEnd(item1)
   fireEvent.transitionEnd(item2)
 

--- a/packages/coreui-react/src/components/collapse/CCollapse.tsx
+++ b/packages/coreui-react/src/components/collapse/CCollapse.tsx
@@ -37,13 +37,19 @@ export const CCollapse = forwardRef<HTMLDivElement, CCollapseProps>(
     const [width, setWidth] = useState<number>()
 
     const onEntering = () => {
-      onShow && onShow()
+      onShow?.()
 
       if (horizontal) {
-        collapseRef.current && setWidth(collapseRef.current.scrollWidth)
+        if (collapseRef.current) {
+          setWidth(collapseRef.current.scrollWidth)
+        }
+
         return
       }
-      collapseRef.current && setHeight(collapseRef.current.scrollHeight)
+
+      if (collapseRef.current) {
+        setHeight(collapseRef.current.scrollHeight)
+      }
     }
 
     const onEntered = () => {
@@ -56,14 +62,20 @@ export const CCollapse = forwardRef<HTMLDivElement, CCollapseProps>(
 
     const onExit = () => {
       if (horizontal) {
-        collapseRef.current && setWidth(collapseRef.current.scrollWidth)
+        if (collapseRef.current) {
+          setWidth(collapseRef.current.scrollWidth)
+        }
+
         return
       }
-      collapseRef.current && setHeight(collapseRef.current.scrollHeight)
+
+      if (collapseRef.current) {
+        setHeight(collapseRef.current.scrollHeight)
+      }
     }
 
     const onExiting = () => {
-      onHide && onHide()
+      onHide?.()
       if (horizontal) {
         setWidth(0)
         return

--- a/packages/coreui-react/src/components/conditional-portal/CConditionalPortal.tsx
+++ b/packages/coreui-react/src/components/conditional-portal/CConditionalPortal.tsx
@@ -37,7 +37,9 @@ export const CConditionalPortal: FC<CConditionalPortalProps> = ({
   const [_container, setContainer] = useState<ReturnType<typeof getContainer>>(null)
 
   useEffect(() => {
-    portal && setContainer(getContainer(container) || document.body)
+    if (portal) {
+      setContainer(getContainer(container) || document.body)
+    }
   }, [container, portal])
 
   return typeof window !== 'undefined' && portal && _container ? (

--- a/packages/coreui-react/src/components/grid/CContainer.tsx
+++ b/packages/coreui-react/src/components/grid/CContainer.tsx
@@ -50,7 +50,9 @@ export const CContainer = forwardRef<HTMLDivElement, CContainerProps>(
       const breakpoint = rest[bp]
       delete rest[bp]
 
-      breakpoint && repsonsiveClassNames.push(`container-${bp}`)
+      if (breakpoint) {
+        repsonsiveClassNames.push(`container-${bp}`)
+      }
     })
 
     return (

--- a/packages/coreui-react/src/components/tabs/CTabPanel.tsx
+++ b/packages/coreui-react/src/components/tabs/CTabPanel.tsx
@@ -44,7 +44,9 @@ export const CTabPanel = forwardRef<HTMLDivElement, CTabPanelProps>(
     const [_visible, setVisible] = useState(visible || _activeItemKey === itemKey)
 
     useEffect(() => {
-      visible !== undefined && setVisible(visible)
+      if (visible !== undefined) {
+        setVisible(visible)
+      }
     }, [visible])
 
     useEffect(() => {

--- a/packages/coreui-react/src/components/tooltip/__tests__/CTooltip.spec.tsx
+++ b/packages/coreui-react/src/components/tooltip/__tests__/CTooltip.spec.tsx
@@ -13,7 +13,7 @@ beforeEach(() => {
 })
 
 afterEach(() => {
-  container && container.remove()
+  container?.remove()
   container = null
 })
 


### PR DESCRIPTION
Part of bringing `yarn lint` to zero (follow-up to #468).

## Change

Converts `cond && fn()` and ternary expression statements into explicit `if` blocks (using optional chaining where it reads better) to satisfy `@typescript-eslint/no-unused-expressions`. **Purely mechanical — no behavior change.**

Files: CCarousel, CCollapse, CContainer, CTabPanel, CConditionalPortal, plus two specs.

## Deliberately out of scope

Three files also flagged by this rule carry **real bugs** that need behavioral fixes (and tests), so they're deferred to a dedicated PR:
- `CCarouselItem` / `CSidebar` — `removeEventListener` called with a fresh inline arrow, so listeners are never actually removed.
- `CLink` — `event.preventDefault` referenced without calling it (missing parens).

## Verification

- Full suite: 127 suites / 358 tests green, no snapshot changes.
- `no-unused-expressions` errors drop from 40 to 17 (the 17 remaining are the three deferred files).