### PR TITLE
fix(CCarouselItem,CSidebar,CLink): remove leaked listeners and dead code

### DIFF
--- a/packages/coreui-react/src/components/carousel/CCarouselItem.tsx
+++ b/packages/coreui-react/src/components/carousel/CCarouselItem.tsx
@@ -64,37 +64,36 @@ export const CCarouselItem = forwardRef<HTMLDivElement, CCarouselItemProps>(
     }, [active])
 
     useEffect(() => {
-      carouselItemRef.current?.addEventListener('transitionstart', () => {
-        active && setAnimating(true)
-      })
-      carouselItemRef.current?.addEventListener('transitionend', () => {
-        active && setAnimating(false)
+      const element = carouselItemRef.current
+
+      if (!element) {
+        return
+      }
+
+      const handleTransitionStart = () => {
+        if (active) {
+          setAnimating(true)
+        }
+      }
+
+      const handleTransitionEnd = () => {
+        if (active) {
+          setAnimating(false)
+        }
+
         setDirectionClassName('')
         setOrderClassName('')
-        if (active) {
-          setActiveClassName('active')
-        }
-        if (!active) {
-          setActiveClassName('')
-        }
-      })
-      return () => {
-        carouselItemRef.current?.removeEventListener('transitionstart', () => {
-          active && setAnimating(true)
-        })
-        carouselItemRef.current?.removeEventListener('transitionend', () => {
-          active && setAnimating(false)
-          setDirectionClassName('')
-          setOrderClassName('')
-          if (active) {
-            setActiveClassName('active')
-          }
-          if (!active) {
-            setActiveClassName('')
-          }
-        })
+        setActiveClassName(active ? 'active' : '')
       }
-    })
+
+      element.addEventListener('transitionstart', handleTransitionStart)
+      element.addEventListener('transitionend', handleTransitionEnd)
+
+      return () => {
+        element.removeEventListener('transitionstart', handleTransitionStart)
+        element.removeEventListener('transitionend', handleTransitionEnd)
+      }
+    }, [active])
 
     return (
       <div

--- a/packages/coreui-react/src/components/carousel/__tests__/CCarouselItem.spec.tsx
+++ b/packages/coreui-react/src/components/carousel/__tests__/CCarouselItem.spec.tsx
@@ -1,0 +1,37 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { CCarousel, CCarouselItem } from '../index'
+
+const isTransition = (type: string) => type === 'transitionstart' || type === 'transitionend'
+
+test('CCarouselItem removes the exact transition listener references on cleanup', async () => {
+  const addSpy = jest.spyOn(HTMLElement.prototype, 'addEventListener')
+  const removeSpy = jest.spyOn(HTMLElement.prototype, 'removeEventListener')
+
+  const { container, unmount } = render(
+    <CCarousel>
+      <CCarouselItem>Item-1</CCarouselItem>
+      <CCarouselItem>Item-2</CCarouselItem>
+    </CCarousel>
+  )
+  const items = new Set<EventTarget>(container.querySelectorAll('.carousel-item'))
+  unmount()
+
+  const handlersOn = (spy: jest.SpyInstance) =>
+    spy.mock.calls
+      .map((args, index) => ({ args, context: spy.mock.contexts[index] }))
+      .filter(({ args, context }) => isTransition(args[0]) && items.has(context as EventTarget))
+      .map(({ args }) => args[1])
+
+  const added = handlersOn(addSpy)
+  const removed = handlersOn(removeSpy)
+
+  expect(added.length).toBeGreaterThan(0)
+  for (const handler of added) {
+    expect(removed).toContain(handler)
+  }
+
+  addSpy.mockRestore()
+  removeSpy.mockRestore()
+})

--- a/packages/coreui-react/src/components/link/CLink.tsx
+++ b/packages/coreui-react/src/components/link/CLink.tsx
@@ -42,8 +42,9 @@ export const CLink: PolymorphicRefForwardingComponent<'a', CLinkProps> = forward
       {...(Component === 'a' && disabled && { 'aria-disabled': true, tabIndex: -1 })}
       {...((Component === 'a' || Component === 'button') && {
         onClick: (event: MouseEvent<HTMLButtonElement | HTMLAnchorElement>) => {
-          event.preventDefault
-          !disabled && rest.onClick && rest.onClick(event)
+          if (!disabled) {
+            rest.onClick?.(event)
+          }
         },
       })}
       disabled={disabled}

--- a/packages/coreui-react/src/components/sidebar/CSidebar.tsx
+++ b/packages/coreui-react/src/components/sidebar/CSidebar.tsx
@@ -101,46 +101,65 @@ export const CSidebar: PolymorphicRefForwardingComponent<'div', CSidebarProps> =
     const [mobile, setMobile] = useState(false)
     const [visibleMobile, setVisibleMobile] = useState<boolean>(false)
     const [visibleDesktop, setVisibleDesktop] = useState<boolean>(
-      visible !== undefined ? visible : overlaid ? false : true
+      visible === undefined ? !overlaid : visible
     )
 
     useEffect(() => {
-      sidebarRef.current && setMobile(isOnMobile(sidebarRef.current))
-      visible !== undefined && handleVisibleChange(visible)
+      if (sidebarRef.current) {
+        setMobile(isOnMobile(sidebarRef.current))
+      }
+
+      if (visible !== undefined) {
+        handleVisibleChange(visible)
+      }
     }, [visible])
 
     useEffect(() => {
-      inViewport !== undefined && onVisibleChange && onVisibleChange(inViewport)
-      !inViewport && onHide && onHide()
-      inViewport && onShow && onShow()
+      if (inViewport !== undefined) {
+        onVisibleChange?.(inViewport)
+      }
+
+      if (inViewport) {
+        onShow?.()
+      } else {
+        onHide?.()
+      }
     }, [inViewport])
 
     useEffect(() => {
-      mobile && setVisibleMobile(false)
+      if (mobile) {
+        setVisibleMobile(false)
+      }
     }, [mobile])
 
     useEffect(() => {
-      sidebarRef.current && setMobile(isOnMobile(sidebarRef.current))
-      sidebarRef.current && setInViewport(isInViewport(sidebarRef.current))
+      const element = sidebarRef.current
+
+      if (element) {
+        setMobile(isOnMobile(element))
+        setInViewport(isInViewport(element))
+      }
+
+      const handleTransitionEnd = () => {
+        if (element) {
+          setInViewport(isInViewport(element))
+        }
+      }
 
       window.addEventListener('resize', handleResize)
       window.addEventListener('mouseup', handleClickOutside)
       window.addEventListener('keyup', handleKeyup)
 
-      sidebarRef.current?.addEventListener('mouseup', handleOnClick)
-      sidebarRef.current?.addEventListener('transitionend', () => {
-        sidebarRef.current && setInViewport(isInViewport(sidebarRef.current))
-      })
+      element?.addEventListener('mouseup', handleOnClick)
+      element?.addEventListener('transitionend', handleTransitionEnd)
 
       return () => {
         window.removeEventListener('resize', handleResize)
         window.removeEventListener('mouseup', handleClickOutside)
         window.removeEventListener('keyup', handleKeyup)
 
-        sidebarRef.current?.removeEventListener('mouseup', handleOnClick)
-        sidebarRef.current?.removeEventListener('transitionend', () => {
-          sidebarRef.current && setInViewport(isInViewport(sidebarRef.current))
-        })
+        element?.removeEventListener('mouseup', handleOnClick)
+        element?.removeEventListener('transitionend', handleTransitionEnd)
       }
     })
 
@@ -158,8 +177,10 @@ export const CSidebar: PolymorphicRefForwardingComponent<'div', CSidebarProps> =
     }
 
     const handleResize = () => {
-      sidebarRef.current && setMobile(isOnMobile(sidebarRef.current))
-      sidebarRef.current && setInViewport(isInViewport(sidebarRef.current))
+      if (sidebarRef.current) {
+        setMobile(isOnMobile(sidebarRef.current))
+        setInViewport(isInViewport(sidebarRef.current))
+      }
     }
 
     const handleKeyup = (event: Event) => {
@@ -183,11 +204,15 @@ export const CSidebar: PolymorphicRefForwardingComponent<'div', CSidebarProps> =
 
     const handleOnClick = (event: Event) => {
       const target = event.target as HTMLAnchorElement
-      target &&
+
+      if (
+        target &&
         target.classList.contains('nav-link') &&
         !target.classList.contains('nav-group-toggle') &&
-        mobile &&
+        mobile
+      ) {
         handleHide()
+      }
     }
 
     return (

--- a/packages/coreui-react/src/components/sidebar/__tests__/CSidebar.spec.tsx
+++ b/packages/coreui-react/src/components/sidebar/__tests__/CSidebar.spec.tsx
@@ -44,3 +44,29 @@ test('CSidebar customize hide', async () => {
   expect(container.firstChild).toHaveClass('sidebar')
   expect(container.firstChild).toHaveClass('sidebar-sticky')
 })
+
+test('CSidebar removes the exact transitionend listener reference on cleanup', async () => {
+  const addSpy = jest.spyOn(HTMLElement.prototype, 'addEventListener')
+  const removeSpy = jest.spyOn(HTMLElement.prototype, 'removeEventListener')
+
+  const { container, unmount } = render(<CSidebar>Test</CSidebar>)
+  const sidebar = container.querySelector('.sidebar')
+  unmount()
+
+  const handlersOn = (spy: jest.SpyInstance) =>
+    spy.mock.calls
+      .map((args, index) => ({ args, context: spy.mock.contexts[index] }))
+      .filter(({ args, context }) => args[0] === 'transitionend' && context === sidebar)
+      .map(({ args }) => args[1])
+
+  const added = handlersOn(addSpy)
+  const removed = handlersOn(removeSpy)
+
+  expect(added.length).toBeGreaterThan(0)
+  for (const handler of added) {
+    expect(removed).toContain(handler)
+  }
+
+  addSpy.mockRestore()
+  removeSpy.mockRestore()
+})


### PR DESCRIPTION
Part of bringing `yarn lint` to zero (follow-up to #468; the third deferred file group from #469).

## Bugs

1. **Leaked transition listeners (CCarouselItem, CSidebar).** Both attached `transitionstart`/`transitionend` listeners with **inline arrow functions** and then called `removeEventListener` with **brand-new inline arrows**. A fresh arrow never equals the one that was registered, so the listeners were never removed — and since the effects had no (CCarouselItem) or an every-render (CSidebar) cadence, they piled up. Flagged by `unicorn/no-invalid-remove-event-listener`.
   - Fix: extract named handlers captured per effect run so add/remove share the same reference; key the carousel-item effect on `active`. The window listeners in CSidebar (already named) and its every-render re-subscribe semantics are unchanged — only the `transitionend` leak is fixed.
2. **CLink dead `event.preventDefault`.** Referenced without calling it (missing parens) — a no-op. Removed per the maintainer's call: behavior is preserved (disabled links already skip the user `onClick`; active links keep navigating).

## Also cleared in these files

`@typescript-eslint/no-unused-expressions` (the `cond && fn()` statements) and one `unicorn/no-negated-condition` in CSidebar's `visibleDesktop` default.

## Tests

New regression tests (`CCarouselItem.spec.tsx`, and one added to `CSidebar.spec.tsx`) spy on `addEventListener`/`removeEventListener`, scope to the component element via `mock.contexts`, and assert **every transition handler added is later removed with the same reference**. Both fail against `main` (verified) and pass with the fix.

Full suite: 127 suites / 360 tests green, no snapshot changes.

> Note: does not touch `CCarousel.spec.tsx` — its `no-unused-expressions` lines are owned by #469. The new carousel-item test lives in its own `CCarouselItem.spec.tsx`, so this PR and #469 don't overlap.