### PR TITLE
refactor(lint): replace any and tighten type idioms

### DIFF
--- a/packages/coreui-react/src/components/carousel/CCarousel.tsx
+++ b/packages/coreui-react/src/components/carousel/CCarousel.tsx
@@ -278,8 +278,8 @@ export const CCarousel = forwardRef<HTMLDivElement, CCarouselProps>(
           <div className="carousel-inner">
             {Children.map(children, (child, index) => {
               if (React.isValidElement(child)) {
-                return React.cloneElement(child as React.ReactElement<any>, {
-                  active: active === index ? true : false,
+                return React.cloneElement(child as React.ReactElement<Record<string, unknown>>, {
+                  active: active === index,
                   direction: direction,
                   key: index,
                 })

--- a/packages/coreui-react/src/components/dropdown/CDropdownToggle.tsx
+++ b/packages/coreui-react/src/components/dropdown/CDropdownToggle.tsx
@@ -106,7 +106,7 @@ export const CDropdownToggle: FC<CDropdownToggleProps> = ({
   if (custom && React.isValidElement(children)) {
     return (
       <>
-        {React.cloneElement(children as React.ReactElement<any>, {
+        {React.cloneElement(children as React.ReactElement<Record<string, unknown>>, {
           'aria-expanded': visible,
           ...(!rest.disabled && { ...triggers }),
           ref: dropdownToggleRef,

--- a/packages/coreui-react/src/components/focus-trap/__tests__/CFocusTrap.spec.tsx
+++ b/packages/coreui-react/src/components/focus-trap/__tests__/CFocusTrap.spec.tsx
@@ -6,7 +6,7 @@ import { CFocusTrap } from '../CFocusTrap'
 // Helper function to create a test component with focusable elements
 interface TestComponentProps {
   children?: React.ReactNode
-  [key: string]: any
+  [key: string]: unknown
 }
 
 const TestComponent = ({ children, ...props }: TestComponentProps) => (

--- a/packages/coreui-react/src/components/table/types.ts
+++ b/packages/coreui-react/src/components/table/types.ts
@@ -1,3 +1,5 @@
+import { CSSProperties } from 'react'
+
 import { CTableDataCellProps } from '../table/CTableDataCell'
 import { CTableHeaderCellProps } from '../table/CTableHeaderCell'
 import { CTableRowProps } from '../table/CTableRow'
@@ -5,7 +7,7 @@ import { CTableRowProps } from '../table/CTableRow'
 export type Column = {
   label?: string
   key: string
-  _style?: any
+  _style?: CSSProperties
   _props?: CTableHeaderCellProps
 }
 

--- a/packages/coreui-react/src/components/table/utils.ts
+++ b/packages/coreui-react/src/components/table/utils.ts
@@ -2,9 +2,9 @@ import type { Column, Item } from './types'
 
 export const pretifyName = (name: string) => {
   return name
-    .replace(/[-_.]/g, ' ')
-    .replace(/ +/g, ' ')
-    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replaceAll(/[-_.]/g, ' ')
+    .replaceAll(/ +/g, ' ')
+    .replaceAll(/([a-z0-9])([A-Z])/g, '$1 $2')
     .split(' ')
     .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
     .join(' ')

--- a/packages/coreui-react/src/helpers/polymorphicComponent.ts
+++ b/packages/coreui-react/src/helpers/polymorphicComponent.ts
@@ -8,7 +8,7 @@ export interface AsProp<As extends ElementType = ElementType> {
   as?: As
 }
 
-export interface Props<As extends ElementType = ElementType> extends AsProp<As> {}
+export type Props<As extends ElementType = ElementType> = AsProp<As>
 
 export interface PolymorphicRefForwardingComponent<TInitial extends ElementType, P = unknown> {
   <As extends ElementType = TInitial>(

--- a/packages/coreui-react/src/hooks/useForkedRef.ts
+++ b/packages/coreui-react/src/hooks/useForkedRef.ts
@@ -13,17 +13,23 @@ export type AssignableRef<ValueType> =
 export function useForkedRef<RefValueType = any>(
   ...refs: (AssignableRef<RefValueType> | null | undefined)[]
 ) {
-  return useMemo(() => {
-    if (refs.every((ref) => ref == null)) {
-      return null
-    }
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return (node: any) => {
-      refs.forEach((ref) => {
-        assignRef(ref, node)
-      })
-    }
-  }, refs)
+  return useMemo(
+    () => {
+      if (refs.every((ref) => ref == null)) {
+        return null
+      }
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return (node: any) => {
+        refs.forEach((ref) => {
+          assignRef(ref, node)
+        })
+      }
+    },
+    // useForkedRef accepts a variable number of refs, so the dependency list
+    // cannot be a static array literal; the refs are compared element-wise.
+    // eslint-disable-next-line react-hooks/use-memo, react-hooks/exhaustive-deps
+    refs
+  )
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -44,7 +50,6 @@ export function assignRef<RefValueType = any>(
   }
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/ban-types
-export function isFunction(value: any): value is Function {
-  return !!(value && {}.toString.call(value) == '[object Function]')
+export function isFunction(value: unknown): value is (...args: unknown[]) => unknown {
+  return typeof value === 'function'
 }

--- a/packages/coreui-react/src/utils/executeAfterTransition.ts
+++ b/packages/coreui-react/src/utils/executeAfterTransition.ts
@@ -25,7 +25,7 @@ const executeAfterTransition = (
 
   let called = false
 
-  const handler = ({ target }: { target: any }) => {
+  const handler = ({ target }: Event) => {
     if (target !== transitionElement) {
       return
     }

--- a/packages/coreui-react/src/utils/mergeClassNames.ts
+++ b/packages/coreui-react/src/utils/mergeClassNames.ts
@@ -9,7 +9,7 @@ const mergeClassNames = <T extends object>(
   const classNames: T = { ...defaultClassNames }
 
   for (const key in customClassNames) {
-    if (customClassNames.hasOwnProperty(key)) {
+    if (Object.hasOwn(customClassNames, key)) {
       const typedKey = key as keyof T
       const customClassName = customClassNames[typedKey]?.toString()
 


### PR DESCRIPTION
Part of bringing `yarn lint` to zero (follow-up to #468/#469/#470). Library type & idiom cleanups — no behavior change.

## Changes

- `table/Column._style`: `any` → `CSSProperties`.
- `CDropdownToggle` / `CCarousel` `cloneElement` targets: `ReactElement<any>` → `ReactElement<Record<string, unknown>>`.
- `executeAfterTransition` handler arg: `{ target }: { target: any }` → `{ target }: Event`.
- `isFunction`: replaced the `Object.prototype.toString` lookup with a `typeof value === 'function'` check and a precise type guard — clears `ban-types`, `no-unsafe-function-type`, and `prefer-prototype-methods` at once.
- `polymorphicComponent`: empty `interface Props extends AsProp {}` → `type Props = AsProp` (`no-empty-object-type`).
- `table/utils` `replace(/…/g)` → `replaceAll`; `mergeClassNames` `obj.hasOwnProperty` → `Object.hasOwn` (both already supported — tsconfig lib is es2023).
- CFocusTrap test helper index signature: `any` → `unknown`.

## Deliberately scoped

- **`useForkedRef`** keeps its variadic `refs` dependency list with a line-scoped `react-hooks/use-memo` disable + comment. The rule requires a static array-literal dep list, which a variadic-arity hook cannot provide; dropping `useMemo` would reintroduce the ref detach/reattach churn from facebook/react#13029. This is a tooling limitation, not a hidden issue.
- **`table/Item`'s `[key: string]: … | any`** is left as-is. Its values are rendered as React children (`{item[colName]}`) while the same shape carries object meta-keys (`_props`/`_cellProps`); tightening it is a public-API typing decision deferred to its own change.

## Verification

- `tsc --noEmit` clean, `yarn lib:build` succeeds (validates `replaceAll`/`Object.hasOwn`).
- Full suite: 127 suites / 360 tests green, no snapshot changes.