### PR TITLE
chore(docs): clear straightforward lint errors

### DIFF
--- a/packages/docs/src/components/ClassNamesDocs.tsx
+++ b/packages/docs/src/components/ClassNamesDocs.tsx
@@ -95,7 +95,7 @@ const ClassNamesDocs = ({ files }: { files: string | string[] }) => {
     return extractCLassNames(_file.default)
   })
 
-  const sortedClassNames = classNames.sort((a, b) => {
+  const sortedClassNames = classNames.toSorted((a, b) => {
     if (a.className < b.className) return -1
     if (a.className > b.className) return 1
     return 0

--- a/packages/docs/src/components/ExampleSnippetLazy.tsx
+++ b/packages/docs/src/components/ExampleSnippetLazy.tsx
@@ -137,15 +137,14 @@ const ExampleSnippetLazy: FC<ExampleSnippetLazyProps> = ({
     <div className="docs-example-snippet" ref={exampleSnippetRef}>
       {visible && (
         <div className={`docs-example ${className}`}>
-          {children ? (
-            children
-          ) : Preview ? (
-            <Suspense fallback={<div>Loading preview...</div>}>
-              <Preview />
-            </Suspense>
-          ) : (
-            <div>No component specified.</div>
-          )}
+          {children ||
+            (Preview ? (
+              <Suspense fallback={<div>Loading preview...</div>}>
+                <Preview />
+              </Suspense>
+            ) : (
+              <div>No component specified.</div>
+            ))}
         </div>
       )}
       <div className="highlight-toolbar border-top">

--- a/packages/docs/src/components/Header.tsx
+++ b/packages/docs/src/components/Header.tsx
@@ -2,18 +2,7 @@ import React, { forwardRef } from 'react'
 import { DocSearch } from '@docsearch/react'
 
 import CIcon, { CIconSvg } from '@coreui/icons-react'
-import {
-  cibGithub,
-  cibOpenCollective,
-  cibTwitter,
-  cilCloudDownload,
-  cilMenu,
-  cilSun,
-  cilMoon,
-  cilContrast,
-  cilHandshake,
-  cilExternalLink,
-} from '@coreui/icons'
+import { cibGithub, cilMenu, cilSun, cilMoon, cilContrast, cilHandshake } from '@coreui/icons'
 
 import {
   CButton,
@@ -31,7 +20,7 @@ import {
 import { AppContext } from './../AppContext'
 import { Link } from 'gatsby'
 
-const Header = forwardRef<HTMLDivElement>(({}, ref) => {
+const Header = forwardRef<HTMLDivElement>((_, ref) => {
   const { colorMode, setColorMode } = useColorModes('coreui-react-docs-theme')
   const isSearchButtonDocsPage =
     typeof window !== 'undefined' && window.location.pathname.includes('/components/search-button/')

--- a/packages/docs/src/components/ScssDocs.tsx
+++ b/packages/docs/src/components/ScssDocs.tsx
@@ -46,7 +46,7 @@ const ScssDocs = ({ file, capture }: ScssDocsProps) => {
   const _file = data.allFile.edges.find((node: any) => node.node.relativePath === file)
   const captureStart = `// scss-docs-start ${capture}\n`
   const captureEnd = `// scss-docs-end ${capture}\n`
-  const re = new RegExp(`${captureStart}([\\s\\S]*?)${captureEnd}`, 'm')
+  const re = new RegExp(String.raw`${captureStart}([\s\S]*?)${captureEnd}`, 'm')
   const captured = re.exec(_file.node.internal.content)
   const code = captured ? captured[1] : undefined
 

--- a/packages/docs/src/components/Seo.tsx
+++ b/packages/docs/src/components/Seo.tsx
@@ -11,6 +11,53 @@ interface SEOProps {
   pro?: boolean
 }
 
+const humanize = (text: string): string => {
+  return text
+    .split('-')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ')
+}
+
+const getDynamicDescription = (pathname: string, name?: string): string => {
+  if (pathname.includes('/components/') && pathname.includes('api')) {
+    return `Complete guide to CoreUI React ${name} API documentation. Learn how to use the CoreUI React ${name} component, its properties, methods, and events.`
+  }
+
+  if (pathname.includes('/components/') && pathname.includes('bootstrap')) {
+    return `Complete guide to CoreUI React ${name} usage with Bootstrap 5. Learn how to use the CoreUI React ${name} component with Bootstrap 5, including its properties, methods, and events.`
+  }
+
+  if (pathname.includes('/components/') && pathname.includes('styling')) {
+    return `Complete guide to CoreUI React ${name} component styling. Learn how to customize the CoreUI React ${name} component styles, themes, and appearance.`
+  }
+
+  if (pathname.includes('/components/')) {
+    return `Complete guide to CoreUI React ${name} components and implementation. Learn how to use the CoreUI React ${name} component in your React.js application.`
+  }
+
+  if (pathname.includes('/customize/')) {
+    return `Complete guide to CoreUI React customization and theming. Learn how to customize CoreUI React components, styles, and themes to fit your project's needs.`
+  }
+
+  if (pathname.includes('/forms/')) {
+    return `Complete guide to CoreUI React ${name} components and implementation.`
+  }
+
+  if (pathname.includes('/layouts/')) {
+    return `Complete guide to CoreUI React ${name} implementation.`
+  }
+
+  if (pathname.includes('/templates/')) {
+    return 'Complete guide to CoreUI React Templates. Learn how to download, install, customize, and use CoreUI React templates.'
+  }
+
+  if (pathname.includes('/migration/')) {
+    return 'Complete guide to CoreUI React migration. Track and review changes to the CoreUI for React.js components to help you migrate to the latest version.'
+  }
+
+  return 'Complete guide to CoreUI for React.js components and implementation.'
+}
+
 const SEO = ({ title, description, name, image, article, pro }: SEOProps) => {
   const { pathname } = useLocation()
   const { site } = useStaticQuery(query)
@@ -36,13 +83,6 @@ const SEO = ({ title, description, name, image, article, pro }: SEOProps) => {
 
   const formattedTitle = title ? titleTemplate.replace('%s', title) : 'My Gatsby Site'
 
-  const humanize = (text: string): string => {
-    return text
-      .split('-')
-      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-      .join(' ')
-  }
-
   const breadcrumbList = (startIndex = 1) => {
     const segments = seo.url
       .replace('docs//', 'docs/')
@@ -62,46 +102,6 @@ const SEO = ({ title, description, name, image, article, pro }: SEOProps) => {
         item: fullPath,
       }
     })
-  }
-
-  const getDynamicDescription = (pathname: string, name?: string): string => {
-    if (pathname.includes('/components/') && pathname.includes('api')) {
-      return `Complete guide to CoreUI React ${name} API documentation. Learn how to use the CoreUI React ${name} component, its properties, methods, and events.`
-    }
-
-    if (pathname.includes('/components/') && pathname.includes('bootstrap')) {
-      return `Complete guide to CoreUI React ${name} usage with Bootstrap 5. Learn how to use the CoreUI React ${name} component with Bootstrap 5, including its properties, methods, and events.`
-    }
-
-    if (pathname.includes('/components/') && pathname.includes('styling')) {
-      return `Complete guide to CoreUI React ${name} component styling. Learn how to customize the CoreUI React ${name} component styles, themes, and appearance.`
-    }
-
-    if (pathname.includes('/components/')) {
-      return `Complete guide to CoreUI React ${name} components and implementation. Learn how to use the CoreUI React ${name} component in your React.js application.`
-    }
-
-    if (pathname.includes('/customize/')) {
-      return `Complete guide to CoreUI React customization and theming. Learn how to customize CoreUI React components, styles, and themes to fit your project's needs.`
-    }
-
-    if (pathname.includes('/forms/')) {
-      return `Complete guide to CoreUI React ${name} components and implementation.`
-    }
-
-    if (pathname.includes('/layouts/')) {
-      return `Complete guide to CoreUI React ${name} implementation.`
-    }
-
-    if (pathname.includes('/templates/')) {
-      return 'Complete guide to CoreUI React Templates. Learn how to download, install, customize, and use CoreUI React templates.'
-    }
-
-    if (pathname.includes('/migration/')) {
-      return 'Complete guide to CoreUI React migration. Track and review changes to the CoreUI for React.js components to help you migrate to the latest version.'
-    }
-
-    return 'Complete guide to CoreUI for React.js components and implementation.'
   }
 
   const schema = [

--- a/packages/docs/src/utils/projectUtils.ts
+++ b/packages/docs/src/utils/projectUtils.ts
@@ -72,7 +72,7 @@ export const getDependencies = (
   }
 
   const sortedDependencies: Record<string, string> = {}
-  const keys = Object.keys(dependencies).sort()
+  const keys = Object.keys(dependencies).toSorted()
   for (const key of keys) {
     sortedDependencies[key] = dependencies[key]
   }


### PR DESCRIPTION
Part of bringing `yarn lint` to zero (follow-up to #468–#471). Docs site only — does not touch the published library.

## Changes

- **Header**: drop unused icon imports (`cibOpenCollective`, `cibTwitter`, `cilCloudDownload`, `cilExternalLink`) and replace the empty `({}, ref)` destructuring with `(_, ref)` (`no-unused-vars`, `no-empty-pattern`).
- **Seo**: hoist the pure `humanize` and `getDynamicDescription` helpers out of the component to module scope (`consistent-function-scoping`).
- **projectUtils / ClassNamesDocs**: `.sort()` → `.toSorted()` (`no-array-sort`).
- **ScssDocs**: `String.raw` for the scss-docs capture regex (`prefer-string-raw`).
- **ExampleSnippetLazy**: collapse `children ? children : …` to `children || …` (`prefer-logical-operator-over-ternary`).

Reduces docs eslint errors from 19 to 8.

## Deliberately deferred

The remaining 8 are a render-time refactor that needs verification against a running docs build, grouped into a dedicated PR with the library's react-hooks v7 work:
- `CodeBlock` / `ScssDocs`: the prismjs language registration assigns `globalThis.Prism` and `require()`s prism components **during render**, with a load-order constraint ESM static imports can't trivially satisfy (`react-hooks/immutability`, `no-require-imports`).
- `ExampleSnippet` / `ExampleSnippetLazy`: `react-hooks/static-components` and `set-state-in-effect`.

No automated tests cover the docs package; changes verified via eslint parse (no tsconfig — Gatsby/babel).