### PR TITLE
refactor(docs): load prismjs grammars at module scope instead of during render

### DIFF
--- a/packages/docs/src/components/CodeBlock.tsx
+++ b/packages/docs/src/components/CodeBlock.tsx
@@ -1,15 +1,13 @@
 import React, { FC } from 'react'
-import { Highlight, Prism } from 'prism-react-renderer'
+import { Highlight } from 'prism-react-renderer'
+
+import '../utils/prism'
 
 export interface CodeBlockProps {
   children: any // eslint-disable-line @typescript-eslint/no-explicit-any
 }
 
 const CodeBlock: FC<CodeBlockProps> = ({ children }) => {
-  ;(typeof globalThis === 'undefined' ? globalThis : globalThis).Prism = Prism
-  // eslint-disable-next-line unicorn/prefer-module
-  require('prismjs/components/prism-bash')
-  require('prismjs/components/prism-scss')
   const _children = children && children.props.children
   const language = children.props.className
     ? children.props.className.replace(/language-/, '')

--- a/packages/docs/src/components/ScssDocs.tsx
+++ b/packages/docs/src/components/ScssDocs.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import { useStaticQuery, graphql } from 'gatsby'
-import { Highlight, Prism } from 'prism-react-renderer'
+import { Highlight } from 'prism-react-renderer'
+
+import '../utils/prism'
 
 export interface ScssDocsProps {
   file: string
@@ -21,10 +23,6 @@ const unindent = (text: string) => {
 }
 
 const ScssDocs = ({ file, capture }: ScssDocsProps) => {
-  ;(typeof global === 'undefined' ? window : global).Prism = Prism
-  // eslint-disable-next-line unicorn/prefer-module
-  require('prismjs/components/prism-scss')
-
   const data = useStaticQuery(graphql`
     query {
       allFile(filter: { ext: { eq: ".scss" } }) {

--- a/packages/docs/src/utils/prism.ts
+++ b/packages/docs/src/utils/prism.ts
@@ -1,0 +1,6 @@
+// Order matters: ./prismGlobal exposes the global Prism instance that the
+// language grammars below register themselves on.
+import './prismGlobal'
+
+import 'prismjs/components/prism-bash'
+import 'prismjs/components/prism-scss'

--- a/packages/docs/src/utils/prismGlobal.ts
+++ b/packages/docs/src/utils/prismGlobal.ts
@@ -1,0 +1,5 @@
+import { Prism } from 'prism-react-renderer'
+
+// prismjs language grammars attach themselves to the global Prism instance, so
+// it has to be exposed before any `prismjs/components/*` module is loaded.
+;(globalThis as typeof globalThis & { Prism: typeof Prism }).Prism = Prism


### PR DESCRIPTION
Follow-up to #472 — clears the prismjs render-time side effects flagged by react-hooks v7.

## Problem

`CodeBlock` and `ScssDocs` set `globalThis.Prism = Prism` and `require()`'d the prismjs language grammars **inside the component body** — i.e. on every render. That tripped `react-hooks/immutability` (mutating during render) and `@typescript-eslint/no-require-imports`.

## Change

Move the setup into two shared modules that run once at import time:

- `utils/prismGlobal.ts` — exposes the global `Prism` instance.
- `utils/prism.ts` — imports `./prismGlobal` **first**, then the `bash`/`scss` grammars that register themselves onto it. ESM evaluates these imports in source order, so the global is set before the grammars load (the load-order constraint that originally forced the runtime `require`).

`CodeBlock` and `ScssDocs` now just `import '../utils/prism'` for its side effect and drop the in-render setup.

## Verification

The docs build runs through webpack (Gatsby), not native ESM. Verified at the module level:
- with `globalThis.Prism` set first, importing the grammars registers them (`Prism.languages.bash` / `.scss` both present);
- the extensionless specifiers resolve to the same `.js` files the original `require()` used (`require.resolve` confirms), so webpack resolves them identically.

Docs eslint errors drop from 8 to 3 (the remaining 3 are the unrelated `ExampleSnippet` react-hooks findings, left for separate work).