### PR TITLE
fix(CCarousel): use the vanilla swipe helper for touch navigation

### DIFF
--- a/packages/coreui-react/src/components/carousel/CCarousel.tsx
+++ b/packages/coreui-react/src/components/carousel/CCarousel.tsx
@@ -1,16 +1,8 @@
-import React, {
-  Children,
-  forwardRef,
-  HTMLAttributes,
-  TouchEvent,
-  useState,
-  useEffect,
-  useRef,
-} from 'react'
+import React, { Children, forwardRef, HTMLAttributes, useState, useEffect, useRef } from 'react'
 import PropTypes from 'prop-types'
 import classNames from 'classnames'
 
-import { isInViewport } from '../../utils'
+import { isInViewport, isRTL, Swipe } from '../../utils'
 import { useForkedRef } from '../../hooks'
 
 import { CCarouselContext } from './CCarouselContext'
@@ -95,13 +87,13 @@ export const CCarousel = forwardRef<HTMLDivElement, CCarouselProps>(
     const carouselRef = useRef<HTMLDivElement>(null)
     const forkedRef = useForkedRef(ref, carouselRef)
     const data = useRef<DataType>({}).current
+    const handleControlClickRef = useRef<(direction: string) => void>(() => undefined)
 
     const [active, setActive] = useState<number>(activeIndex)
     const [animating, setAnimating] = useState<boolean>(false)
     const [customInterval, setCustomInterval] = useState<boolean | number>()
     const [direction, setDirection] = useState<string>('next')
     const [itemsNumber, setItemsNumber] = useState<number>(0)
-    const [touchPosition, setTouchPosition] = useState<number | null>(null)
     const [visible, setVisible] = useState<boolean>()
 
     useEffect(() => {
@@ -130,6 +122,19 @@ export const CCarousel = forwardRef<HTMLDivElement, CCarouselProps>(
         window.removeEventListener('scroll', handleScroll)
       }
     }, [])
+
+    useEffect(() => {
+      if (!touch || !carouselRef.current) {
+        return
+      }
+
+      const swipe = new Swipe(carouselRef.current, {
+        onLeft: () => handleControlClickRef.current(isRTL(carouselRef.current) ? 'prev' : 'next'),
+        onRight: () => handleControlClickRef.current(isRTL(carouselRef.current) ? 'next' : 'prev'),
+      })
+
+      return () => swipe.dispose()
+    }, [touch])
 
     useEffect(() => {
       return () => clearCycleTimeout()
@@ -179,6 +184,7 @@ export const CCarousel = forwardRef<HTMLDivElement, CCarouselProps>(
         setActive(active === 0 ? itemsNumber - 1 : active - 1)
       }
     }
+    handleControlClickRef.current = handleControlClick
 
     const handleIndicatorClick = (index: number) => {
       if (active === index) {
@@ -205,32 +211,6 @@ export const CCarousel = forwardRef<HTMLDivElement, CCarouselProps>(
       }
     }
 
-    const handleTouchMove = (e: TouchEvent) => {
-      const touchDown = touchPosition
-
-      if (touchDown === null) {
-        return
-      }
-
-      const currentTouch = e.touches[0].clientX
-      const diff = touchDown - currentTouch
-
-      if (diff > 5) {
-        handleControlClick('next')
-      }
-
-      if (diff < -5) {
-        handleControlClick('prev')
-      }
-
-      setTouchPosition(null)
-    }
-
-    const handleTouchStart = (e: TouchEvent) => {
-      const touchDown = e.touches[0].clientX
-      setTouchPosition(touchDown)
-    }
-
     return (
       <div
         className={classNames(
@@ -243,7 +223,6 @@ export const CCarousel = forwardRef<HTMLDivElement, CCarouselProps>(
         {...(dark && { 'data-coreui-theme': 'dark' })}
         onMouseEnter={_pause}
         onMouseLeave={cycle}
-        {...(touch && { onTouchStart: handleTouchStart, onTouchMove: handleTouchMove })}
         {...rest}
         ref={forkedRef}
       >

--- a/packages/coreui-react/src/utils/__tests__/swipe.spec.ts
+++ b/packages/coreui-react/src/utils/__tests__/swipe.spec.ts
@@ -1,0 +1,82 @@
+import Swipe from '../swipe'
+
+const touchEvent = (type: string, clientX: number): Event => {
+  const event = new Event(type) as Event & { touches: { clientX: number }[] }
+  event.touches = [{ clientX }]
+  return event
+}
+
+describe('Swipe', () => {
+  let element: HTMLElement
+  const originalPointerEvent = window.PointerEvent
+
+  beforeEach(() => {
+    element = document.createElement('div')
+    document.body.appendChild(element)
+    // Force the touch-event path and make the helper consider touch supported.
+    ;(window as unknown as { PointerEvent?: unknown }).PointerEvent = undefined
+    Object.defineProperty(navigator, 'maxTouchPoints', { value: 1, configurable: true })
+  })
+
+  afterEach(() => {
+    element.remove()
+    ;(window as unknown as { PointerEvent?: unknown }).PointerEvent = originalPointerEvent
+  })
+
+  it('reports support when touch points are available', () => {
+    expect(Swipe.isSupported()).toBe(true)
+  })
+
+  it('calls onLeft when swiping left past the threshold', () => {
+    const onLeft = jest.fn()
+    const onRight = jest.fn()
+    const onEnd = jest.fn()
+    new Swipe(element, { onLeft, onRight, onEnd })
+
+    element.dispatchEvent(touchEvent('touchstart', 200))
+    element.dispatchEvent(touchEvent('touchmove', 100))
+    element.dispatchEvent(touchEvent('touchend', 100))
+
+    expect(onLeft).toHaveBeenCalledTimes(1)
+    expect(onRight).not.toHaveBeenCalled()
+    expect(onEnd).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onRight when swiping right past the threshold', () => {
+    const onLeft = jest.fn()
+    const onRight = jest.fn()
+    new Swipe(element, { onLeft, onRight })
+
+    element.dispatchEvent(touchEvent('touchstart', 100))
+    element.dispatchEvent(touchEvent('touchmove', 200))
+    element.dispatchEvent(touchEvent('touchend', 200))
+
+    expect(onRight).toHaveBeenCalledTimes(1)
+    expect(onLeft).not.toHaveBeenCalled()
+  })
+
+  it('ignores swipes below the threshold', () => {
+    const onLeft = jest.fn()
+    const onRight = jest.fn()
+    new Swipe(element, { onLeft, onRight })
+
+    element.dispatchEvent(touchEvent('touchstart', 200))
+    element.dispatchEvent(touchEvent('touchmove', 180))
+    element.dispatchEvent(touchEvent('touchend', 180))
+
+    expect(onLeft).not.toHaveBeenCalled()
+    expect(onRight).not.toHaveBeenCalled()
+  })
+
+  it('stops detecting swipes after dispose', () => {
+    const onLeft = jest.fn()
+    const swipe = new Swipe(element, { onLeft })
+    swipe.dispose()
+
+    element.dispatchEvent(touchEvent('touchstart', 200))
+    element.dispatchEvent(touchEvent('touchmove', 100))
+    element.dispatchEvent(touchEvent('touchend', 100))
+
+    expect(onLeft).not.toHaveBeenCalled()
+  })
+})

--- a/packages/coreui-react/src/utils/index.ts
+++ b/packages/coreui-react/src/utils/index.ts
@@ -5,6 +5,7 @@ import getTransitionDurationFromElement from './getTransitionDurationFromElement
 import isInViewport from './isInViewport'
 import isRTL from './isRTL'
 import mergeClassNames from './mergeClassNames'
+import Swipe from './swipe'
 
 export {
   executeAfterTransition,
@@ -14,4 +15,5 @@ export {
   isInViewport,
   isRTL,
   mergeClassNames,
+  Swipe,
 }

--- a/packages/coreui-react/src/utils/swipe.ts
+++ b/packages/coreui-react/src/utils/swipe.ts
@@ -1,0 +1,114 @@
+const SWIPE_THRESHOLD = 40
+const POINTER_TYPE_TOUCH = 'touch'
+const POINTER_TYPE_PEN = 'pen'
+const CLASS_NAME_POINTER_EVENT = 'pointer-event'
+
+export interface SwipeCallbacks {
+  onLeft?: () => void
+  onRight?: () => void
+  onEnd?: () => void
+}
+
+/**
+ * Detects horizontal swipe gestures on an element, using Pointer events when
+ * available and falling back to Touch events otherwise. A modified port of the
+ * vanilla `@coreui/coreui` swipe helper.
+ */
+class Swipe {
+  private readonly element: HTMLElement
+  private readonly callbacks: SwipeCallbacks
+  private deltaX = 0
+  private readonly supportPointerEvents = Boolean(window.PointerEvent)
+
+  constructor(element: HTMLElement, callbacks: SwipeCallbacks = {}) {
+    this.element = element
+    this.callbacks = callbacks
+
+    if (!element || !Swipe.isSupported()) {
+      return
+    }
+
+    this.initEvents()
+  }
+
+  static isSupported(): boolean {
+    return 'ontouchstart' in document.documentElement || navigator.maxTouchPoints > 0
+  }
+
+  dispose(): void {
+    this.element.removeEventListener('pointerdown', this.start)
+    this.element.removeEventListener('pointerup', this.end)
+    this.element.removeEventListener('touchstart', this.start)
+    this.element.removeEventListener('touchmove', this.move)
+    this.element.removeEventListener('touchend', this.end)
+    this.element.classList.remove(CLASS_NAME_POINTER_EVENT)
+  }
+
+  private readonly start = (event: PointerEvent | TouchEvent): void => {
+    if (!this.supportPointerEvents) {
+      this.deltaX = (event as TouchEvent).touches[0].clientX
+      return
+    }
+
+    if (this.eventIsPointerPenTouch(event as PointerEvent)) {
+      this.deltaX = (event as PointerEvent).clientX
+    }
+  }
+
+  private readonly move = (event: TouchEvent): void => {
+    this.deltaX =
+      event.touches && event.touches.length > 1 ? 0 : event.touches[0].clientX - this.deltaX
+  }
+
+  private readonly end = (event: PointerEvent | TouchEvent): void => {
+    if (this.eventIsPointerPenTouch(event as PointerEvent)) {
+      this.deltaX = (event as PointerEvent).clientX - this.deltaX
+    }
+
+    this.handleSwipe()
+    this.callbacks.onEnd?.()
+  }
+
+  private handleSwipe(): void {
+    const absDeltaX = Math.abs(this.deltaX)
+
+    if (absDeltaX <= SWIPE_THRESHOLD) {
+      return
+    }
+
+    const direction = absDeltaX / this.deltaX
+
+    this.deltaX = 0
+
+    if (!direction) {
+      return
+    }
+
+    if (direction > 0) {
+      this.callbacks.onRight?.()
+    } else {
+      this.callbacks.onLeft?.()
+    }
+  }
+
+  private eventIsPointerPenTouch(event: PointerEvent): boolean {
+    return (
+      this.supportPointerEvents &&
+      (event.pointerType === POINTER_TYPE_PEN || event.pointerType === POINTER_TYPE_TOUCH)
+    )
+  }
+
+  private initEvents(): void {
+    if (this.supportPointerEvents) {
+      this.element.addEventListener('pointerdown', this.start)
+      this.element.addEventListener('pointerup', this.end)
+      this.element.classList.add(CLASS_NAME_POINTER_EVENT)
+    } else {
+      this.element.addEventListener('touchstart', this.start)
+      this.element.addEventListener('touchmove', this.move)
+      this.element.addEventListener('touchend', this.end)
+    }
+  }
+}
+
+export default Swipe


### PR DESCRIPTION
The carousel's touch handling was a simplified inline implementation: a **5px** threshold, firing **mid-gesture** on `touchmove`, with **no Pointer event support** and **no RTL awareness**. This replaces it with a faithful port of the vanilla `@coreui/coreui` swipe helper.

## What

- **New `utils/Swipe`** — Pointer events with a Touch-event fallback, a **40px** threshold, detecting the gesture on **release** (`pointerup` / `touchend`). Mirrors the vanilla `util/swipe.js`.
- **CCarousel** now wires the helper through a single `useEffect` (keyed on `touch`), reading the latest `handleControlClick` via a ref to avoid stale closures.
- **RTL aware**: swipe→prev/next mapping is flipped under `dir="rtl"` (matching vanilla's `_directionToOrder`), checked per gesture against the carousel element.

No public API change — the `touch` prop and `onSlide` / `onSlid` events are unchanged; only the gesture detection is corrected.

## Tests & verification

- New `utils/__tests__/swipe.spec.ts` covers threshold, direction, and dispose.
- `yarn lib:test` — 365/365 passing · `yarn lib:build` OK · scoped lint clean (no new errors).