### PR TITLE
release: v5.12.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@
 
 Several quick start options are available:
 
-- [Download the latest release](https://github.com/coreui/coreui-react/archive/v5.11.0.zip)
+- [Download the latest release](https://github.com/coreui/coreui-react/archive/v5.12.0.zip)
 - Clone the repo: `git clone https://github.com/coreui/coreui-react.git`
 - Install with [npm](https://www.npmjs.com/): `npm install @coreui/react`
 - Install with [yarn](https://yarnpkg.com/): `yarn add @coreui/react`

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "npmClient": "yarn",
   "packages": ["packages/*"],
-  "version": "5.11.0",
+  "version": "5.12.0",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }

--- a/package.json
+++ b/package.json
@@ -22,18 +22,18 @@
     "test:update": "npm-run-all charts:test:update icons:test:update lib:test:update"
   },
   "devDependencies": {
-    "@typescript-eslint/parser": "^8.59.3",
+    "@typescript-eslint/parser": "^8.61.0",
     "eslint": "^9.39.4",
     "eslint-config-prettier": "^10.1.8",
-    "eslint-plugin-prettier": "^5.5.5",
+    "eslint-plugin-prettier": "^5.5.6",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-unicorn": "^62.0.0",
     "globals": "^16.5.0",
     "lerna": "^9.0.7",
     "npm-run-all": "^4.1.5",
-    "prettier": "^3.8.3",
-    "typescript-eslint": "^8.59.3"
+    "prettier": "^3.8.4",
+    "typescript-eslint": "^8.61.0"
   },
   "overrides": {
     "gatsby-remark-external-links": {

--- a/packages/coreui-react/README.md
+++ b/packages/coreui-react/README.md
@@ -46,7 +46,7 @@
 
 Several quick start options are available:
 
-- [Download the latest release](https://github.com/coreui/coreui-react/archive/v5.11.0.zip)
+- [Download the latest release](https://github.com/coreui/coreui-react/archive/v5.12.0.zip)
 - Clone the repo: `git clone https://github.com/coreui/coreui-react.git`
 - Install with [npm](https://www.npmjs.com/): `npm install @coreui/react`
 - Install with [yarn](https://yarnpkg.com/): `yarn add @coreui/react`

--- a/packages/coreui-react/package.json
+++ b/packages/coreui-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coreui/react",
-  "version": "5.11.0",
+  "version": "5.12.0",
   "description": "UI Components Library for React.js",
   "keywords": [
     "react",
@@ -41,12 +41,12 @@
     "test:update": "jest --coverage --updateSnapshot"
   },
   "dependencies": {
-    "@coreui/coreui": "^5.7.0",
+    "@coreui/coreui": "^5.8.0",
     "@popperjs/core": "^2.11.8",
     "prop-types": "^15.8.1"
   },
   "devDependencies": {
-    "@rollup/plugin-commonjs": "^29.0.2",
+    "@rollup/plugin-commonjs": "^29.0.3",
     "@rollup/plugin-node-resolve": "^16.0.3",
     "@rollup/plugin-typescript": "^12.3.0",
     "@testing-library/dom": "^10.4.1",
@@ -54,7 +54,7 @@
     "@testing-library/react": "^16.3.2",
     "@types/jest": "^30.0.0",
     "@types/prop-types": "15.7.15",
-    "@types/react": "^19.2.14",
+    "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@types/react-transition-group": "^4.4.12",
     "classnames": "^2.5.1",
@@ -64,8 +64,8 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-transition-group": "^4.4.5",
-    "rollup": "^4.60.4",
-    "ts-jest": "^29.4.9",
+    "rollup": "^4.62.0",
+    "ts-jest": "^29.4.11",
     "tslib": "^2.8.1",
     "typescript": "^5.9.3"
   },

--- a/packages/docs/content/api/CNavGroup.api.mdx
+++ b/packages/docs/content/api/CNavGroup.api.mdx
@@ -52,7 +52,7 @@ import CNavGroup from '@coreui/react/src/components/nav/CNavGroup'
       </tr>
       <tr>
         <td colSpan="3">
-          <p>Callback fired when the user toggles the group. Receives the requested visibility. In controlled mode (<code>{`visible`}</code> set), update <code>{`visible`}</code> from here—or ignore the change to keep the group as is.</p>
+          <p>Callback fired when the user toggles the group. Receives the requested visibility. Provide it together with <code>{`visible`}</code> for controlled mode—update <code>{`visible`}</code> from here, or ignore the change to keep the group as is.</p>
         </td>
       </tr>
       <tr id="cnavgroup-toggler">
@@ -72,7 +72,7 @@ import CNavGroup from '@coreui/react/src/components/nav/CNavGroup'
       </tr>
       <tr>
         <td colSpan="3">
-          <p>Show nav group items.</p>
+          <p>Show nav group items. Acts as the initial state when used on its own, or as the controlled value when paired with <code>{`onVisibleChange`}</code>.</p>
         </td>
       </tr>
     </tbody>

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coreui/react-docs",
-  "version": "5.11.0",
+  "version": "5.12.0",
   "private": true,
   "description": "",
   "homepage": "https://coreui.io/react/",
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@coreui/chartjs": "^4.2.0",
-    "@coreui/coreui": "^5.7.0",
+    "@coreui/coreui": "^5.8.0",
     "@coreui/icons": "^3.1.0",
     "@coreui/icons-react": "^2.3.0",
     "@coreui/internal-links": "^5.1.0",
@@ -60,7 +60,7 @@
     "react-imask": "^7.6.1",
     "react-markdown": "^10.1.0",
     "rimraf": "^6.1.3",
-    "sass": "^1.99.0",
+    "sass": "^1.101.0",
     "showdown": "^2.1.0"
   },
   "devDependencies": {

--- a/packages/docs/src/components/Seo.tsx
+++ b/packages/docs/src/components/Seo.tsx
@@ -154,7 +154,7 @@ const SEO = ({ title, description, name, image, article, pro }: SEOProps) => {
         '@type': 'WebPage',
         '@id': seo.url.replace('docs//', 'docs/'),
       },
-      version: pro ? '5.17.1' : '5.11.0',
+      version: pro ? '5.17.1' : '5.12.0',
       proficiencyLevel: 'Beginner',
     },
   ]

--- a/packages/remark-code-tabs/package.json
+++ b/packages/remark-code-tabs/package.json
@@ -12,8 +12,8 @@
   ],
   "description": "Gatsby plugin to embed jsx code preview",
   "dependencies": {
-    "unist-util-is": "^6.0.0",
-    "unist-util-visit": "^5.0.0"
+    "unist-util-is": "^6.0.1",
+    "unist-util-visit": "^5.1.0"
   },
   "main": "index.js"
 }


### PR DESCRIPTION
## Release v5.12.0

Prepares the `@coreui/react` 5.11.0 → **5.12.0** release.

### Highlights
- `feat(Chip)`: new **CChipSet** / **CChipInput** components (filter chips, data-driven `chips`, `selectionMode`, RTL navigation).
- `feat(CNavGroup)`: controlled visibility, `onVisibleChange`, context-based accordion.
- Numerous fixes (CCarousel, CModal, CTooltip/CPopover, CDropdown — leaked listeners/timers) plus lint/CI cleanup.

### Version bump
`lerna.json`, `packages/coreui-react/package.json`, `packages/docs/package.json`, `README.md` (×2), `Seo.tsx` → 5.12.0. Regenerated `docs:api` (CNavGroup).

### Dependencies (within current major only — no breaking changes)
- `@coreui/coreui` ^5.7 → ^5.8
- `rollup` ^4.60 → ^4.62, `@rollup/plugin-commonjs` ^29.0.2 → ^29.0.3
- `@types/react` ^19.2.14 → ^19.2.17, `ts-jest` ^29.4.9 → ^29.4.11
- `prettier` ^3.8.3 → ^3.8.4, `@typescript-eslint/parser` + `typescript-eslint` ^8.59 → ^8.61, `eslint-plugin-prettier` ^5.5.5 → ^5.5.6
- `sass` ^1.99 → ^1.101, `unist-util-is`/`unist-util-visit` (remark-code-tabs)

### Skipped (major — deferred, decide separately)
`jest` 30, `jest-environment-jsdom` 30, `react`/`react-dom` 19, `typescript` 6, `eslint` 10, `eslint-plugin-unicorn` 65, `globals` 17, and the markdown tooling in the gatsby/remark plugins (`unified` 11, `remark-*`, `rehype-*`, `mdast-*`, `micromark-*`, `unist-util-map`/`-visit-parents`, `normalize-path`).

### Verification
- `yarn lib:build` ✅
- `yarn lib:test` ✅ — 129 suites / 365 tests / 282 snapshots

> Tag + `npm publish` handled by the maintainer.