### PR TITLE
chore: pin react/react-dom to 18.3.1 for deterministic dedupe

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,10 @@
     "test": "npm-run-all charts:test icons:test lib:test",
     "test:update": "npm-run-all charts:test:update icons:test:update lib:test:update"
   },
+  "resolutions": {
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  },
   "devDependencies": {
     "@typescript-eslint/parser": "^8.62.0",
     "eslint": "^9.39.4",


### PR DESCRIPTION
Adds a `resolutions` pin so the monorepo always installs a single `react@18.3.1` instance.

The docs workspace (`@coreui/react-docs`) depends on `react@^19.2.7`. yarn can hoist react@19 to the repo root and push the library + react-dom onto their own nested react@18 copies — multiple React instances → "invalid hook call" (`useRef` on null) in jsdom tests. That is exactly what was failing ~144 test suites in `coreui-react-pro` (fixed there with the same pin). `coreui-react` happens to hoist react@18 today, so its tests pass — but only by luck of install order. This pin makes it deterministic.

No behavior change; lib build + tests stay green (129 suites / 365 tests).