### PR TITLE
feat(CAlert): add transition, onClosed and ariaCloseLabel

### DIFF
--- a/packages/coreui-react/src/components/alert/CAlert.tsx
+++ b/packages/coreui-react/src/components/alert/CAlert.tsx
@@ -11,6 +11,12 @@ import type { Colors } from '../../types'
 
 export interface CAlertProps extends HTMLAttributes<HTMLDivElement> {
   /**
+   * Sets the `aria-label` of the dismissible close button.
+   *
+   * @since 5.13.0
+   */
+  ariaCloseLabel?: string
+  /**
    * A string of all className you want applied to the component.
    */
   className?: string
@@ -54,6 +60,7 @@ export const CAlert = forwardRef<HTMLDivElement, CAlertProps>(
   (
     {
       children,
+      ariaCloseLabel = 'Close',
       className,
       color = 'primary',
       dismissible,
@@ -101,7 +108,9 @@ export const CAlert = forwardRef<HTMLDivElement, CAlertProps>(
             ref={forkedRef}
           >
             {children}
-            {dismissible && <CCloseButton onClick={() => setVisible(false)} />}
+            {dismissible && (
+              <CCloseButton aria-label={ariaCloseLabel} onClick={() => setVisible(false)} />
+            )}
           </div>
         )}
       </Transition>
@@ -110,6 +119,7 @@ export const CAlert = forwardRef<HTMLDivElement, CAlertProps>(
 )
 
 CAlert.propTypes = {
+  ariaCloseLabel: PropTypes.string,
   children: PropTypes.node,
   className: PropTypes.string,
   color: colorPropType.isRequired,

--- a/packages/coreui-react/src/components/alert/CAlert.tsx
+++ b/packages/coreui-react/src/components/alert/CAlert.tsx
@@ -29,6 +29,18 @@ export interface CAlertProps extends HTMLAttributes<HTMLDivElement> {
    */
   onClose?: () => void
   /**
+   * Callback fired when the component has been closed and the CSS transition has completed.
+   *
+   * @since 5.13.0
+   */
+  onClosed?: () => void
+  /**
+   * Set whether the alert fades in and out when it is shown and hidden. Set to `false` to make it appear and disappear without a fade animation.
+   *
+   * @since 5.13.0
+   */
+  transition?: boolean
+  /**
    * Set the alert variant to a solid.
    */
   variant?: 'solid' | string
@@ -45,9 +57,11 @@ export const CAlert = forwardRef<HTMLDivElement, CAlertProps>(
       className,
       color = 'primary',
       dismissible,
+      transition = true,
       variant,
       visible = true,
       onClose,
+      onClosed,
       ...rest
     },
     ref
@@ -66,7 +80,8 @@ export const CAlert = forwardRef<HTMLDivElement, CAlertProps>(
         mountOnEnter
         nodeRef={alertRef}
         onExit={onClose}
-        timeout={150}
+        onExited={onClosed}
+        timeout={transition ? 150 : 0}
         unmountOnExit
       >
         {(state) => (
@@ -75,7 +90,8 @@ export const CAlert = forwardRef<HTMLDivElement, CAlertProps>(
               'alert',
               variant === 'solid' ? `bg-${color} text-white` : `alert-${color}`,
               {
-                'alert-dismissible fade': dismissible,
+                'alert-dismissible': dismissible,
+                fade: transition,
                 show: state === 'entered',
               },
               className
@@ -99,6 +115,8 @@ CAlert.propTypes = {
   color: colorPropType.isRequired,
   dismissible: PropTypes.bool,
   onClose: PropTypes.func,
+  onClosed: PropTypes.func,
+  transition: PropTypes.bool,
   variant: PropTypes.string,
   visible: PropTypes.bool,
 }

--- a/packages/coreui-react/src/components/alert/__tests__/CAlert.spec.tsx
+++ b/packages/coreui-react/src/components/alert/__tests__/CAlert.spec.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { act, render, fireEvent } from '@testing-library/react'
+import { act, render, fireEvent, waitFor } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import { CAlert } from '../index'
 
@@ -61,6 +61,35 @@ describe('CAlert', () => {
 
       expect(onClose).toHaveBeenCalledTimes(1)
       vi.useRealTimers()
+    })
+
+    it('should emit closed after the transition', async () => {
+      const onClosed = vi.fn()
+      const { container } = render(
+        <CAlert color="primary" dismissible onClosed={onClosed}>
+          Test
+        </CAlert>
+      )
+
+      fireEvent.click(container.querySelector('.btn-close')!)
+
+      await waitFor(() => expect(onClosed).toHaveBeenCalledTimes(1))
+    })
+  })
+
+  describe('transition', () => {
+    it('should apply the fade class', () => {
+      const { container } = render(<CAlert color="primary">Test</CAlert>)
+      expect(container.firstChild).toHaveClass('fade')
+    })
+
+    it('should not apply the fade class when transition is disabled', () => {
+      const { container } = render(
+        <CAlert color="primary" transition={false}>
+          Test
+        </CAlert>
+      )
+      expect(container.firstChild).not.toHaveClass('fade')
     })
   })
 

--- a/packages/coreui-react/src/components/alert/__tests__/CAlert.spec.tsx
+++ b/packages/coreui-react/src/components/alert/__tests__/CAlert.spec.tsx
@@ -45,6 +45,15 @@ describe('CAlert', () => {
       expect(container.querySelector('.btn-close')).toBeInTheDocument()
     })
 
+    it('should set a custom close button label', () => {
+      const { container } = render(
+        <CAlert color="primary" dismissible ariaCloseLabel="Zamknij">
+          Test
+        </CAlert>
+      )
+      expect(container.querySelector('.btn-close')).toHaveAttribute('aria-label', 'Zamknij')
+    })
+
     it('should close an alert', () => {
       vi.useFakeTimers()
       const onClose = vi.fn()

--- a/packages/docs/src/api/CAlert.api.json
+++ b/packages/docs/src/api/CAlert.api.json
@@ -2,6 +2,14 @@
   "name": "CAlert",
   "props": [
     {
+      "name": "ariaCloseLabel",
+      "type": "string | undefined",
+      "default": "Close",
+      "description": "Sets the `aria-label` of the dismissible close button.",
+      "since": "5.13.0",
+      "deprecated": null
+    },
+    {
       "name": "className",
       "type": "string | undefined",
       "default": null,

--- a/packages/docs/src/api/CAlert.api.json
+++ b/packages/docs/src/api/CAlert.api.json
@@ -34,6 +34,22 @@
       "deprecated": null
     },
     {
+      "name": "onClosed",
+      "type": "(() => void) | undefined",
+      "default": null,
+      "description": "Callback fired when the component has been closed and the CSS transition has completed.",
+      "since": "5.13.0",
+      "deprecated": null
+    },
+    {
+      "name": "transition",
+      "type": "boolean | undefined",
+      "default": true,
+      "description": "Set whether the alert fades in and out when it is shown and hidden. Set to `false` to make it appear and disappear without a fade animation.",
+      "since": "5.13.0",
+      "deprecated": null
+    },
+    {
       "name": "variant",
       "type": "string | undefined",
       "default": null,


### PR DESCRIPTION
Adds fade control and the after-transition close event to `CAlert`, reconciling a cross-framework divergence found by the alert test-parity work.

## API
- **`transition?: boolean`** (default `true`, matching `CModal`) — controls the fade animation. `fade` is now decoupled from `dismissible`.
- **`onClosed?: () => void`** — fired after the close transition finishes (`onExited`), mirroring Bootstrap's `closed.coreui.alert` event (the existing `onClose` maps to the immediate `close`).

## Behavior change (minor)
`fade` was previously hardcoded whenever `dismissible`; it's now driven by `transition`. A **non-dismissible alert now fades by default**, and `transition={false}` disables the animation. This matches `CModal` and Bootstrap's opt-in fade model.

## Tests
Adds a `transition` group (`should apply the fade class`, `should not apply the fade class when transition is disabled`) and `should emit closed after the transition`. Full suite green.

Ports the same API to Vue (coreui-vue feat/alert-transition).