### PR TITLE
fix(CButton): render directly instead of via CLink; add aria-pressed

### DIFF
--- a/packages/coreui-react/src/components/button/CButton.tsx
+++ b/packages/coreui-react/src/components/button/CButton.tsx
@@ -1,8 +1,8 @@
-import React, { ElementType, forwardRef } from 'react'
+import React, { ElementType, forwardRef, MouseEvent } from 'react'
 import PropTypes from 'prop-types'
 import classNames from 'classnames'
 
-import { CLink, CLinkProps } from '../link/CLink'
+import { CLinkProps } from '../link/CLink'
 
 import { PolymorphicRefForwardingComponent } from '../../helpers'
 import { colorPropType } from '../../props'
@@ -65,13 +65,27 @@ export const CButton: PolymorphicRefForwardingComponent<'button', CButtonProps> 
   CButtonProps
 >(
   (
-    { children, as = 'button', className, color, shape, size, type = 'button', variant, ...rest },
+    {
+      children,
+      active,
+      as = 'button',
+      className,
+      color,
+      disabled,
+      href,
+      onClick,
+      shape,
+      size,
+      type = 'button',
+      variant,
+      ...rest
+    },
     ref
   ) => {
+    const Component = href ? 'a' : as
+
     return (
-      <CLink
-        as={rest.href ? 'a' : as}
-        {...(!rest.href && { type: type })}
+      <Component
         className={classNames(
           'btn',
           {
@@ -79,15 +93,26 @@ export const CButton: PolymorphicRefForwardingComponent<'button', CButtonProps> 
             [`btn-${variant}`]: variant && !color,
             [`btn-${color}`]: !variant && color,
             [`btn-${size}`]: size,
+            active,
+            disabled,
           },
           shape,
           className
         )}
+        {...((Component === 'button' || Component === 'input') && { type, disabled })}
+        {...(active && { 'aria-pressed': true })}
+        {...(Component === 'a' && href && { href })}
+        {...(Component === 'a' && disabled && { 'aria-disabled': true, tabIndex: -1 })}
+        onClick={(event: MouseEvent<HTMLButtonElement | HTMLAnchorElement>) => {
+          if (!disabled) {
+            onClick?.(event)
+          }
+        }}
         {...rest}
         ref={ref}
       >
         {children}
-      </CLink>
+      </Component>
     )
   }
 )

--- a/packages/coreui-react/src/components/button/__tests__/CButton.spec.tsx
+++ b/packages/coreui-react/src/components/button/__tests__/CButton.spec.tsx
@@ -52,6 +52,11 @@ describe('CButton', () => {
       expect(container.firstChild).toHaveClass('active')
     })
 
+    it('should set aria-pressed when active', () => {
+      const { container } = render(<CButton active>Test</CButton>)
+      expect(container.firstChild).toHaveAttribute('aria-pressed', 'true')
+    })
+
     it('should be disabled', () => {
       const { container } = render(<CButton disabled>Test</CButton>)
       expect(container.firstChild).toBeDisabled()
@@ -85,6 +90,12 @@ describe('CButton', () => {
     it('should render as a custom element', () => {
       const { container } = render(<CButton as="span">Test</CButton>)
       expect(container.firstChild?.nodeName).toBe('SPAN')
+    })
+
+    it('should render as an input with the button type', () => {
+      const { container } = render(<CButton as="input" type="submit" value="Submit" />)
+      expect(container.firstChild?.nodeName).toBe('INPUT')
+      expect(container.firstChild).toHaveAttribute('type', 'submit')
     })
 
     it('should render as a link when href is set', () => {


### PR DESCRIPTION
Surfaced by the button test-parity work: `CButton` rendered through `CLink`, a **navigation-focused** component, which leaked link semantics onto the button.

## Fixes
- **No more `aria-current="page"` leak.** `CLink` added `aria-current="page"` when `active` — wrong for a button. `CButton` now renders the resolved element directly.
- **`aria-pressed`.** Adds `aria-pressed="true"` when `active` (toggle-button semantics, matching the vanilla Button plugin). Only when active.
- **`type` on inputs.** `type` is applied to `<input>` (as="input") as well as `<button>`.
- **Correct `disabled`.** The `disabled` attribute is set only on `button`/`input`; `<a>` gets `aria-disabled` + `tabindex="-1"` (previously `CLink` set a `disabled` attribute on every element).

Mirrors the Vue edition's direct-render structure; `CLink` stays where it belongs (links). Adds `should set aria-pressed when active` and `should render as an input with the button type`. Full suite green (389).