### PR TITLE
feat(CButton): add toggle prop and render without the CLink wrapper

### DIFF
--- a/packages/coreui-react/src/components/button/CButton.tsx
+++ b/packages/coreui-react/src/components/button/CButton.tsx
@@ -1,8 +1,8 @@
-import React, { ElementType, forwardRef } from 'react'
+import React, { ElementType, forwardRef, MouseEvent, useEffect, useState } from 'react'
 import PropTypes from 'prop-types'
 import classNames from 'classnames'
 
-import { CLink, CLinkProps } from '../link/CLink'
+import { CLinkProps } from '../link/CLink'
 
 import { PolymorphicRefForwardingComponent } from '../../helpers'
 import { colorPropType } from '../../props'
@@ -50,6 +50,12 @@ export interface CButtonProps extends Omit<CLinkProps, 'size'> {
    */
   size?: 'sm' | 'lg'
   /**
+   * Make the button behave as a toggle button. It manages its own active/pressed state, toggling it on click and reflecting it via the `aria-pressed` attribute.
+   *
+   * @since 5.13.0
+   */
+  toggle?: boolean
+  /**
    * Specifies the type of button. Always specify the type attribute for the `<button>` element.
    * Different browsers may use different default types for the `<button>` element.
    */
@@ -65,13 +71,33 @@ export const CButton: PolymorphicRefForwardingComponent<'button', CButtonProps> 
   CButtonProps
 >(
   (
-    { children, as = 'button', className, color, shape, size, type = 'button', variant, ...rest },
+    {
+      children,
+      active,
+      as = 'button',
+      className,
+      color,
+      disabled,
+      href,
+      onClick,
+      shape,
+      size,
+      toggle,
+      type = 'button',
+      variant,
+      ...rest
+    },
     ref
   ) => {
+    const Component = href ? 'a' : as
+    const [_active, setActive] = useState(active)
+
+    useEffect(() => {
+      setActive(active)
+    }, [active])
+
     return (
-      <CLink
-        as={rest.href ? 'a' : as}
-        {...(!rest.href && { type: type })}
+      <Component
         className={classNames(
           'btn',
           {
@@ -79,26 +105,44 @@ export const CButton: PolymorphicRefForwardingComponent<'button', CButtonProps> 
             [`btn-${variant}`]: variant && !color,
             [`btn-${color}`]: !variant && color,
             [`btn-${size}`]: size,
+            active: _active,
+            disabled,
           },
           shape,
           className
         )}
+        {...((Component === 'button' || Component === 'input') && { type, disabled })}
+        {...(toggle && { 'aria-pressed': !!_active })}
+        {...(Component === 'a' && href && { href })}
+        {...(Component === 'a' && disabled && { 'aria-disabled': true, tabIndex: -1 })}
+        onClick={(event: MouseEvent<HTMLButtonElement | HTMLAnchorElement>) => {
+          if (!disabled) {
+            if (toggle) {
+              event.preventDefault()
+              setActive((prevActive) => !prevActive)
+            }
+
+            onClick?.(event)
+          }
+        }}
         {...rest}
         ref={ref}
       >
         {children}
-      </CLink>
+      </Component>
     )
   }
 )
 
 CButton.propTypes = {
+  active: PropTypes.bool,
   as: PropTypes.elementType,
   children: PropTypes.node,
   className: PropTypes.string,
   color: colorPropType,
   shape: PropTypes.string,
   size: PropTypes.oneOf(['sm', 'lg']),
+  toggle: PropTypes.bool,
   type: PropTypes.oneOf(['button', 'submit', 'reset']),
   variant: PropTypes.oneOf(['outline', 'ghost']),
 }

--- a/packages/coreui-react/src/components/button/__tests__/CButton.spec.tsx
+++ b/packages/coreui-react/src/components/button/__tests__/CButton.spec.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { render, fireEvent } from '@testing-library/react'
+import { render, fireEvent, createEvent } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import { CButton } from '../index'
 
@@ -52,6 +52,50 @@ describe('CButton', () => {
       expect(container.firstChild).toHaveClass('active')
     })
 
+    it('should forward the aria-pressed attribute', () => {
+      // toggle buttons opt in to aria-pressed themselves (it is not implied by active)
+      const { container } = render(
+        <CButton active aria-pressed={true}>
+          Test
+        </CButton>
+      )
+      expect(container.firstChild).toHaveAttribute('aria-pressed', 'true')
+    })
+
+    it('should toggle the active state on click', () => {
+      const { container } = render(<CButton toggle>Test</CButton>)
+      const button = container.firstChild as HTMLElement
+      expect(button).not.toHaveClass('active')
+      expect(button).toHaveAttribute('aria-pressed', 'false')
+      fireEvent.click(button)
+      expect(button).toHaveClass('active')
+      expect(button).toHaveAttribute('aria-pressed', 'true')
+      fireEvent.click(button)
+      expect(button).not.toHaveClass('active')
+      expect(button).toHaveAttribute('aria-pressed', 'false')
+    })
+
+    it('should seed the toggle state from the active prop', () => {
+      const { container } = render(
+        <CButton toggle active>
+          Test
+        </CButton>
+      )
+      expect(container.firstChild).toHaveClass('active')
+      expect(container.firstChild).toHaveAttribute('aria-pressed', 'true')
+    })
+
+    it('should prevent the default action on a toggle click', () => {
+      const { container } = render(
+        <CButton as="a" href="#" toggle>
+          Test
+        </CButton>
+      )
+      const event = createEvent.click(container.firstChild as HTMLElement)
+      fireEvent(container.firstChild as HTMLElement, event)
+      expect(event.defaultPrevented).toBe(true)
+    })
+
     it('should be disabled', () => {
       const { container } = render(<CButton disabled>Test</CButton>)
       expect(container.firstChild).toBeDisabled()
@@ -85,6 +129,12 @@ describe('CButton', () => {
     it('should render as a custom element', () => {
       const { container } = render(<CButton as="span">Test</CButton>)
       expect(container.firstChild?.nodeName).toBe('SPAN')
+    })
+
+    it('should render as an input with the button type', () => {
+      const { container } = render(<CButton as="input" type="submit" value="Submit" />)
+      expect(container.firstChild?.nodeName).toBe('INPUT')
+      expect(container.firstChild).toHaveAttribute('type', 'submit')
     })
 
     it('should render as a link when href is set', () => {

--- a/packages/docs/src/api/CButton.api.json
+++ b/packages/docs/src/api/CButton.api.json
@@ -74,6 +74,14 @@
       "deprecated": null
     },
     {
+      "name": "toggle",
+      "type": "boolean | undefined",
+      "default": null,
+      "description": "Make the button behave as a toggle button. It manages its own active/pressed state, toggling it on click and reflecting it via the `aria-pressed` attribute.",
+      "since": "5.13.0",
+      "deprecated": null
+    },
+    {
       "name": "type",
       "type": "\"button\" | \"submit\" | \"reset\" | undefined",
       "default": "button",

--- a/packages/docs/src/api/CDropdownToggle.api.json
+++ b/packages/docs/src/api/CDropdownToggle.api.json
@@ -114,6 +114,14 @@
       "deprecated": null
     },
     {
+      "name": "toggle",
+      "type": "boolean | undefined",
+      "default": null,
+      "description": "Make the button behave as a toggle button. It manages its own active/pressed state, toggling it on click and reflecting it via the `aria-pressed` attribute.",
+      "since": "5.13.0",
+      "deprecated": null
+    },
+    {
       "name": "trigger",
       "type": "'hover' | 'focus' | 'click'",
       "default": "click",

--- a/packages/docs/src/api/CToastClose.api.json
+++ b/packages/docs/src/api/CToastClose.api.json
@@ -66,6 +66,14 @@
       "deprecated": null
     },
     {
+      "name": "toggle",
+      "type": "boolean | undefined",
+      "default": null,
+      "description": "Make the button behave as a toggle button. It manages its own active/pressed state, toggling it on click and reflecting it via the `aria-pressed` attribute.",
+      "since": "5.13.0",
+      "deprecated": null
+    },
+    {
       "name": "type",
       "type": "\"button\" | \"submit\" | \"reset\" | undefined",
       "default": null,

--- a/packages/docs/src/content/docs/components/button/examples/ButtonToggleExample.tsx
+++ b/packages/docs/src/content/docs/components/button/examples/ButtonToggleExample.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import { CButton } from '@coreui/react'
+
+export const ButtonToggleExample = () => {
+  return (
+    <>
+      <div className="d-flex gap-1 mb-3">
+        <CButton toggle>Toggle button</CButton>
+        <CButton toggle active>
+          Active toggle button
+        </CButton>
+        <CButton toggle disabled>
+          Disabled toggle button
+        </CButton>
+      </div>
+      <div className="d-flex gap-1">
+        <CButton color="primary" toggle>
+          Toggle button
+        </CButton>
+        <CButton color="primary" toggle active>
+          Active toggle button
+        </CButton>
+        <CButton color="primary" toggle disabled>
+          Disabled toggle button
+        </CButton>
+      </div>
+    </>
+  )
+}

--- a/packages/docs/src/content/docs/components/button/examples/ButtonToggleLinkExample.tsx
+++ b/packages/docs/src/content/docs/components/button/examples/ButtonToggleLinkExample.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import { CButton } from '@coreui/react'
+
+export const ButtonToggleLinkExample = () => {
+  return (
+    <>
+      <div className="d-flex gap-1 mb-3">
+        <CButton as="a" href="#" role="button" toggle>
+          Toggle link
+        </CButton>
+        <CButton as="a" href="#" role="button" toggle active>
+          Active toggle link
+        </CButton>
+        <CButton as="a" role="button" toggle disabled>
+          Disabled toggle link
+        </CButton>
+      </div>
+      <div className="d-flex gap-1">
+        <CButton as="a" color="primary" href="#" role="button" toggle>
+          Toggle link
+        </CButton>
+        <CButton as="a" color="primary" href="#" role="button" toggle active>
+          Active toggle link
+        </CButton>
+        <CButton as="a" color="primary" role="button" toggle disabled>
+          Disabled toggle link
+        </CButton>
+      </div>
+    </>
+  )
+}

--- a/packages/docs/src/content/docs/components/button/index.mdx
+++ b/packages/docs/src/content/docs/components/button/index.mdx
@@ -41,6 +41,10 @@ import { ButtonBlock3Example } from './examples/ButtonBlock3Example'
 import ButtonBlock3ExampleRaw from './examples/ButtonBlock3Example.tsx?raw'
 import { ButtonBlock4Example } from './examples/ButtonBlock4Example'
 import ButtonBlock4ExampleRaw from './examples/ButtonBlock4Example.tsx?raw'
+import { ButtonToggleExample } from './examples/ButtonToggleExample'
+import ButtonToggleExampleRaw from './examples/ButtonToggleExample.tsx?raw'
+import { ButtonToggleLinkExample } from './examples/ButtonToggleLinkExample'
+import ButtonToggleLinkExampleRaw from './examples/ButtonToggleLinkExample.tsx?raw'
 
 ## How to use React Button Component.
 
@@ -185,6 +189,24 @@ Additional utilities can be used to adjust the alignment of buttons when horizon
 
 <Example code={ButtonBlock4ExampleRaw} name="ButtonBlock4Example" componentName="React Button">
   <ButtonBlock4Example client:only="react" />
+</Example>
+
+## Toggle states
+
+Add the `toggle` boolean prop to create simple on/off toggle buttons. A toggle button manages its own state: on click it flips the `.active` class and the `aria-pressed` attribute. Seed the initial state with the `active` prop.
+
+<Callout color="info">
+Visually, these toggle buttons are identical to the [checkbox toggle buttons](/forms/checks-radios/#checkbox-toggle-buttons). However, they are conveyed differently by assistive technologies: the checkbox toggles will be announced by screen readers as "checked"/"not checked" (since, despite their appearance, they are fundamentally still checkboxes), whereas these toggle buttons will be announced as "button"/"button pressed". The choice between these two approaches will depend on the type of toggle you are creating, and whether or not the toggle will make sense to users when announced as a checkbox or as an actual button.
+</Callout>
+
+<Example code={ButtonToggleExampleRaw} name="ButtonToggleExample" componentName="React Button">
+  <ButtonToggleExample client:only="react" />
+</Example>
+
+Toggle links behave the same way:
+
+<Example code={ButtonToggleLinkExampleRaw} name="ButtonToggleLinkExample" componentName="React Button">
+  <ButtonToggleLinkExample client:only="react" />
 </Example>
 
 ## API


### PR DESCRIPTION
## Toggle buttons

Adds a `toggle` boolean prop that turns `CButton` into a self-managed toggle button, mirroring vanilla's `data-coreui-toggle="button"` plugin:

- seeds its active state from the `active` prop,
- flips it on click,
- reflects the state via the `.active` class and `aria-pressed`.

Without `toggle`, `active` stays purely visual (no implied `aria-pressed`), matching vanilla where a plain `.active` button carries no `aria-pressed`.

## Render reconcile

`CButton` now renders the button element directly instead of wrapping `CLink`. Wrapping `CLink` leaked `aria-current="page"` onto `active` buttons, which is wrong semantics for a button. It also now sets `type` when rendering as an `<input>`.

## Docs & tests

- New "Toggle states" docs section with button and link examples, matching the vanilla page.
- Canonical parity tests shared verbatim with `coreui-vue` (toggle on click, seed from `active`, aria-pressed forwarding, input type).
- Regenerated API tables.

`@since 5.13.0`