### PR TITLE
fix(CToastClose, CDropdownToggle): drop unintended props inherited from CButton

### DIFF
--- a/packages/coreui-react/src/components/dropdown/CDropdownToggle.tsx
+++ b/packages/coreui-react/src/components/dropdown/CDropdownToggle.tsx
@@ -8,7 +8,7 @@ import { CDropdownContext } from './CDropdownContext'
 import { triggerPropType } from '../../props'
 import type { Triggers } from '../../types'
 
-export interface CDropdownToggleProps extends Omit<CButtonProps, 'type'> {
+export interface CDropdownToggleProps extends Omit<CButtonProps, 'toggle' | 'type'> {
   /**
    * Enables pseudo element caret on toggler.
    */

--- a/packages/coreui-react/src/components/toast/CToastClose.tsx
+++ b/packages/coreui-react/src/components/toast/CToastClose.tsx
@@ -1,15 +1,12 @@
 import React, { ElementType, forwardRef, useContext } from 'react'
 import PropTypes from 'prop-types'
 
-import { CButtonProps } from '../button/CButton'
 import { CCloseButton, CCloseButtonProps } from '../close-button/CCloseButton'
 import { CToastContext } from './CToastContext'
 
 import { PolymorphicRefForwardingComponent } from '../../helpers'
 
-type CombineButtonProps = CCloseButtonProps & CButtonProps
-
-export interface CToastCloseProps extends Omit<CombineButtonProps, 'as'> {
+export interface CToastCloseProps extends CCloseButtonProps {
   /**
    * Component used for the root node. Either a string to use a HTML element or a component.
    */

--- a/packages/docs/src/api/CDropdownToggle.api.json
+++ b/packages/docs/src/api/CDropdownToggle.api.json
@@ -114,14 +114,6 @@
       "deprecated": null
     },
     {
-      "name": "toggle",
-      "type": "boolean | undefined",
-      "default": null,
-      "description": "Make the button behave as a toggle button. It manages its own active/pressed state, toggling it on click and reflecting it via the `aria-pressed` attribute.",
-      "since": "5.13.0",
-      "deprecated": null
-    },
-    {
       "name": "trigger",
       "type": "'hover' | 'focus' | 'click'",
       "default": "click",

--- a/packages/docs/src/api/CToastClose.api.json
+++ b/packages/docs/src/api/CToastClose.api.json
@@ -2,14 +2,6 @@
   "name": "CToastClose",
   "props": [
     {
-      "name": "active",
-      "type": "boolean | undefined",
-      "default": null,
-      "description": "Toggle the active state for the component.",
-      "since": null,
-      "deprecated": null
-    },
-    {
       "name": "as",
       "type": "(ElementType & string) | (ElementType & ComponentClass<any, any>) | (ElementType & FunctionComponent<any>) | undefined",
       "default": null,
@@ -38,54 +30,6 @@
       "type": "boolean | undefined",
       "default": null,
       "description": "Toggle the disabled state for the component.",
-      "since": null,
-      "deprecated": null
-    },
-    {
-      "name": "href",
-      "type": "string | undefined",
-      "default": null,
-      "description": "The href attribute specifies the URL of the page the link goes to.",
-      "since": null,
-      "deprecated": null
-    },
-    {
-      "name": "shape",
-      "type": "'rounded' | 'rounded-top' | 'rounded-end' | 'rounded-bottom' | 'rounded-start' | 'rounded-circle' | 'rounded-pill' | 'rounded-0' | 'rounded-1' | 'rounded-2' | 'rounded-3' | string",
-      "default": null,
-      "description": "Select the shape of the component.",
-      "since": null,
-      "deprecated": null
-    },
-    {
-      "name": "size",
-      "type": "\"sm\" | \"lg\" | undefined",
-      "default": null,
-      "description": "Size the component small or large.",
-      "since": null,
-      "deprecated": null
-    },
-    {
-      "name": "toggle",
-      "type": "boolean | undefined",
-      "default": null,
-      "description": "Make the button behave as a toggle button. It manages its own active/pressed state, toggling it on click and reflecting it via the `aria-pressed` attribute.",
-      "since": "5.13.0",
-      "deprecated": null
-    },
-    {
-      "name": "type",
-      "type": "\"button\" | \"submit\" | \"reset\" | undefined",
-      "default": null,
-      "description": "Specifies the type of button. Always specify the type attribute for the `<button>` element.\nDifferent browsers may use different default types for the `<button>` element.",
-      "since": null,
-      "deprecated": null
-    },
-    {
-      "name": "variant",
-      "type": "\"outline\" | \"ghost\" | undefined",
-      "default": null,
-      "description": "Set the button variant to an outlined button or a ghost button.",
       "since": null,
       "deprecated": null
     },


### PR DESCRIPTION
#495 added the `toggle` prop to `CButton`, which leaked into the generated API docs of every component whose props interface extends `CButtonProps`:

- **CToastClose** — extended `CCloseButtonProps & CButtonProps`, so its API table listed `toggle` (plus `active`, `href`, `shape`, `size`, `type`, `variant`) even though the component renders a `CCloseButton` by default. The `CButtonProps` intersection was a leftover: the polymorphic helper already derives prop types from the component passed via `as` (`ComponentPropsWithRef<As>`), so the interface now extends `CCloseButtonProps` only — matching the Vue edition's API surface.
- **CDropdownToggle** — genuinely renders a `CButton`, so it keeps `CButtonProps`, but now omits `toggle`: the dropdown manages its own open state via `aria-expanded`, and a self-toggling `aria-pressed` button would conflict with that.

API JSON regenerated. `lib:build`, tests, and lint pass.