### PR TITLE
feat(CCloseButton, CModalHeader, CToastHeader): allow customizing the close button aria-label

### DIFF
--- a/packages/coreui-react/src/components/close-button/CCloseButton.tsx
+++ b/packages/coreui-react/src/components/close-button/CCloseButton.tsx
@@ -4,6 +4,12 @@ import classNames from 'classnames'
 
 export interface CCloseButtonProps extends HTMLAttributes<HTMLButtonElement> {
   /**
+   * Sets the `aria-label` attribute of the close button.
+   *
+   * @default 'Close'
+   */
+  'aria-label'?: string
+  /**
    * A string of all className you want applied to the base component.
    */
   className?: string
@@ -24,7 +30,7 @@ export interface CCloseButtonProps extends HTMLAttributes<HTMLButtonElement> {
 }
 
 export const CCloseButton = forwardRef<HTMLButtonElement, CCloseButtonProps>(
-  ({ className, dark, disabled, white, ...rest }, ref) => {
+  ({ 'aria-label': ariaLabel = 'Close', className, dark, disabled, white, ...rest }, ref) => {
     return (
       <button
         type="button"
@@ -37,7 +43,7 @@ export const CCloseButton = forwardRef<HTMLButtonElement, CCloseButtonProps>(
           disabled,
           className
         )}
-        aria-label="Close"
+        aria-label={ariaLabel}
         disabled={disabled}
         {...(dark && { 'data-coreui-theme': 'dark' })}
         {...rest}
@@ -48,6 +54,7 @@ export const CCloseButton = forwardRef<HTMLButtonElement, CCloseButtonProps>(
 )
 
 CCloseButton.propTypes = {
+  'aria-label': PropTypes.string,
   className: PropTypes.string,
   dark: PropTypes.bool,
   disabled: PropTypes.bool,

--- a/packages/coreui-react/src/components/close-button/__tests__/CCloseButton.spec.tsx
+++ b/packages/coreui-react/src/components/close-button/__tests__/CCloseButton.spec.tsx
@@ -12,6 +12,11 @@ test('loads and displays CCloseButton component', async () => {
   expect(container).toMatchSnapshot()
 })
 
+test('CCloseButton allows overriding the default aria-label', async () => {
+  render(<CCloseButton aria-label="Dismiss" />)
+  expect(document.querySelector('button')).toHaveAttribute('aria-label', 'Dismiss')
+})
+
 test('CCloseButton customize', async () => {
   const { container } = render(<CCloseButton white={true} disabled={true} className="bazinga" />)
   const button = document.querySelector('button')

--- a/packages/coreui-react/src/components/modal/CModalHeader.tsx
+++ b/packages/coreui-react/src/components/modal/CModalHeader.tsx
@@ -7,6 +7,12 @@ import { CModalContext } from './CModalContext'
 
 export interface CModalHeaderProps extends HTMLAttributes<HTMLDivElement> {
   /**
+   * Sets the `aria-label` of the close button.
+   *
+   * @since 5.13.0
+   */
+  ariaCloseLabel?: string
+  /**
    * A string of all className you want applied to the base component.
    */
   className?: string
@@ -17,19 +23,22 @@ export interface CModalHeaderProps extends HTMLAttributes<HTMLDivElement> {
 }
 
 export const CModalHeader = forwardRef<HTMLDivElement, CModalHeaderProps>(
-  ({ children, className, closeButton = true, ...rest }, ref) => {
+  ({ children, ariaCloseLabel, className, closeButton = true, ...rest }, ref) => {
     const { setVisible } = useContext(CModalContext)
 
     return (
       <div className={classNames('modal-header', className)} {...rest} ref={ref}>
         {children}
-        {closeButton && <CCloseButton onClick={() => setVisible(false)} />}
+        {closeButton && (
+          <CCloseButton aria-label={ariaCloseLabel} onClick={() => setVisible(false)} />
+        )}
       </div>
     )
   }
 )
 
 CModalHeader.propTypes = {
+  ariaCloseLabel: PropTypes.string,
   children: PropTypes.node,
   className: PropTypes.string,
   closeButton: PropTypes.bool,

--- a/packages/coreui-react/src/components/modal/__tests__/CModalHeader.spec.tsx
+++ b/packages/coreui-react/src/components/modal/__tests__/CModalHeader.spec.tsx
@@ -15,6 +15,11 @@ test('CModalHeader customize', async () => {
   expect(container.firstChild).toHaveClass('modal-header')
 })
 
+test('CModalHeader sets the aria-label of the close button via ariaCloseLabel', async () => {
+  render(<CModalHeader ariaCloseLabel="Dismiss">Test</CModalHeader>)
+  expect(document.querySelector('.btn-close')).toHaveAttribute('aria-label', 'Dismiss')
+})
+
 test('CModalHeader has a close button', async () => {
   const onDismiss = vi.fn()
   render(<CModalHeader className="bazinga">Test</CModalHeader>)

--- a/packages/coreui-react/src/components/toast/CToastHeader.tsx
+++ b/packages/coreui-react/src/components/toast/CToastHeader.tsx
@@ -6,6 +6,12 @@ import { CToastClose } from './CToastClose'
 
 export interface CToastHeaderProps extends Omit<HTMLAttributes<HTMLDivElement>, 'title'> {
   /**
+   * Sets the `aria-label` of the close button.
+   *
+   * @since 5.13.0
+   */
+  ariaCloseLabel?: string
+  /**
    * A string of all className you want applied to the base component.
    */
   className?: string
@@ -16,17 +22,18 @@ export interface CToastHeaderProps extends Omit<HTMLAttributes<HTMLDivElement>, 
 }
 
 export const CToastHeader = forwardRef<HTMLDivElement, CToastHeaderProps>(
-  ({ children, className, closeButton, ...rest }, ref) => {
+  ({ children, ariaCloseLabel, className, closeButton, ...rest }, ref) => {
     return (
       <div className={classNames('toast-header', className)} {...rest} ref={ref}>
         {children}
-        {closeButton && <CToastClose />}
+        {closeButton && <CToastClose aria-label={ariaCloseLabel} />}
       </div>
     )
   }
 )
 
 CToastHeader.propTypes = {
+  ariaCloseLabel: PropTypes.string,
   children: PropTypes.node,
   className: PropTypes.string,
   closeButton: PropTypes.bool,

--- a/packages/coreui-react/src/components/toast/__tests__/CToastHeader.spec.tsx
+++ b/packages/coreui-react/src/components/toast/__tests__/CToastHeader.spec.tsx
@@ -8,6 +8,15 @@ test('loads and displays CToastHeader component', async () => {
   expect(container).toMatchSnapshot()
 })
 
+test('CToastHeader sets the aria-label of the close button via ariaCloseLabel', async () => {
+  render(
+    <CToastHeader closeButton ariaCloseLabel="Dismiss">
+      Test
+    </CToastHeader>
+  )
+  expect(document.querySelector('.btn-close')).toHaveAttribute('aria-label', 'Dismiss')
+})
+
 test('CToastHeader customize', async () => {
   const { container } = render(<CToastHeader className="bazinga">Test</CToastHeader>)
   expect(container).toMatchSnapshot()

--- a/packages/docs/src/api/CCloseButton.api.json
+++ b/packages/docs/src/api/CCloseButton.api.json
@@ -2,6 +2,14 @@
   "name": "CCloseButton",
   "props": [
     {
+      "name": "aria-label",
+      "type": "string | undefined",
+      "default": "Close",
+      "description": "Sets the `aria-label` attribute of the close button.",
+      "since": null,
+      "deprecated": null
+    },
+    {
       "name": "className",
       "type": "string | undefined",
       "default": null,

--- a/packages/docs/src/api/CModalHeader.api.json
+++ b/packages/docs/src/api/CModalHeader.api.json
@@ -2,6 +2,14 @@
   "name": "CModalHeader",
   "props": [
     {
+      "name": "ariaCloseLabel",
+      "type": "string | undefined",
+      "default": null,
+      "description": "Sets the `aria-label` of the close button.",
+      "since": "5.13.0",
+      "deprecated": null
+    },
+    {
       "name": "className",
       "type": "string | undefined",
       "default": null,

--- a/packages/docs/src/api/CToastClose.api.json
+++ b/packages/docs/src/api/CToastClose.api.json
@@ -2,6 +2,14 @@
   "name": "CToastClose",
   "props": [
     {
+      "name": "aria-label",
+      "type": "string | undefined",
+      "default": "'Close'",
+      "description": "Sets the `aria-label` attribute of the close button.",
+      "since": null,
+      "deprecated": null
+    },
+    {
       "name": "as",
       "type": "(ElementType & string) | (ElementType & ComponentClass<any, any>) | (ElementType & FunctionComponent<any>) | undefined",
       "default": null,

--- a/packages/docs/src/api/CToastHeader.api.json
+++ b/packages/docs/src/api/CToastHeader.api.json
@@ -2,6 +2,14 @@
   "name": "CToastHeader",
   "props": [
     {
+      "name": "ariaCloseLabel",
+      "type": "string | undefined",
+      "default": null,
+      "description": "Sets the `aria-label` of the close button.",
+      "since": "5.13.0",
+      "deprecated": null
+    },
+    {
       "name": "className",
       "type": "string | undefined",
       "default": null,


### PR DESCRIPTION
`CCloseButton` renders a hardcoded-looking `aria-label="Close"`, which made the label impossible to localize through `CModalHeader closeButton` and `CToastHeader closeButton`, and the override that did exist (native `aria-label` via rest spread) was undocumented.

- **CCloseButton** — the native `aria-label` attribute is now an explicitly declared, documented prop with a `'Close'` default (same approach as react-bootstrap's `CloseButton`; ARIA attributes stay kebab-case in React).
- **CModalHeader / CToastHeader** — new `ariaCloseLabel` prop (mirrors the existing `CAlert.ariaCloseLabel`, `@since 5.13.0`) passed through to the embedded close button.
- Tests added for the override and both passthroughs; API JSON regenerated.