### PR TITLE
docs: add AI Tools section (MCP Server + LLMs.txt)

### DIFF
--- a/packages/docs/src/content/docs/ai-tools/llms-txt.mdx
+++ b/packages/docs/src/content/docs/ai-tools/llms-txt.mdx
@@ -8,7 +8,7 @@ description: "LLM-optimized documentation endpoints for CoreUI for React — llm
 
 [llms.txt](https://llmstxt.org) is an emerging standard that helps AI models understand and navigate documentation. The CoreUI for React docs expose three LLM-friendly endpoints so assistants can retrieve accurate, up-to-date content straight from the source.
 
-For a richer, tool-based integration, see [AI Tools (MCP)](/react/docs/getting-started/ai-tools/).
+For a richer, tool-based integration, see [MCP Server](/react/docs/ai-tools/mcp/).
 
 ## /llms.txt
 

--- a/packages/docs/src/content/docs/ai-tools/mcp.mdx
+++ b/packages/docs/src/content/docs/ai-tools/mcp.mdx
@@ -1,6 +1,6 @@
 ---
-title: "AI Tools (MCP)"
-name: "AI Tools (MCP)"
+title: "MCP Server"
+name: "MCP Server"
 description: "Bring the CoreUI for React documentation into your AI coding assistant with the @coreui/docs-mcp Model Context Protocol server."
 ---
 

--- a/packages/docs/src/content/docs/getting-started/ai-tools.mdx
+++ b/packages/docs/src/content/docs/getting-started/ai-tools.mdx
@@ -4,25 +4,32 @@ name: "AI Tools (MCP)"
 description: "Bring the CoreUI for React documentation into your AI coding assistant with the @coreui/docs-mcp Model Context Protocol server."
 ---
 
-## What is the CoreUI Docs MCP server?
+## Introduction
 
-[Model Context Protocol (MCP)](https://modelcontextprotocol.io) is an open standard that lets AI assistants connect to external tools and data sources. The **`@coreui/docs-mcp`** server exposes the official CoreUI documentation — components, props, events, slots, and examples — so your assistant answers from the current docs instead of relying on stale training data.
+[Model Context Protocol (MCP)](https://modelcontextprotocol.io) is an open standard that lets AI assistants connect to external tools and data sources. The **`@coreui/docs-mcp`** server gives your assistant direct access to the official CoreUI documentation, so it answers from the current docs instead of relying on stale training data.
 
-It covers Bootstrap, React, and Vue, and reads the live documentation from `coreui.io` on demand, so it always reflects the latest release.
+It provides:
+
+- **Component documentation** — pages, props, events, and slots.
+- **Live content** — read on demand from `coreui.io`, always matching the latest release.
+- **Cross-framework links** — where each component is documented for Angular, Bootstrap, React, and Vue.
+- **Coverage of Bootstrap, React, and Vue** from a single server.
+
+The server runs locally over stdio via `npx` — no global install required.
 
 ## Installation
 
-The server runs over stdio via `npx` — no global install required.
-
 ### Claude Code
 
+Add the server with the CLI, then start a new session and run `/mcp` to verify the connection:
+
 ```bash
-claude mcp add coreui-docs -- npx -y @coreui/docs-mcp --framework react
+claude mcp add coreui-docs -s user -- npx -y @coreui/docs-mcp --framework react
 ```
 
-### Cursor, Windsurf, VS Code, and Claude Desktop
+### Cursor
 
-Add the server to your MCP configuration (`.cursor/mcp.json`, `.vscode/mcp.json`, `claude_desktop_config.json`, and similar):
+Create `.cursor/mcp.json` in your project (or `~/.cursor/mcp.json` for global configuration):
 
 ```json
 {
@@ -33,6 +40,66 @@ Add the server to your MCP configuration (`.cursor/mcp.json`, `.vscode/mcp.json`
     }
   }
 }
+```
+
+### VS Code
+
+Create `.vscode/mcp.json` in your project. Note that VS Code uses the `servers` key:
+
+```json
+{
+  "servers": {
+    "coreui-docs": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@coreui/docs-mcp", "--framework", "react"]
+    }
+  }
+}
+```
+
+### Windsurf
+
+Edit `~/.codeium/windsurf/mcp_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "coreui-docs": {
+      "command": "npx",
+      "args": ["-y", "@coreui/docs-mcp", "--framework", "react"]
+    }
+  }
+}
+```
+
+### Claude Desktop
+
+Edit `claude_desktop_config.json` (Settings → Developer → Edit Config):
+
+```json
+{
+  "mcpServers": {
+    "coreui-docs": {
+      "command": "npx",
+      "args": ["-y", "@coreui/docs-mcp", "--framework", "react"]
+    }
+  }
+}
+```
+
+### OpenAI Codex
+
+Add it with the CLI, or edit `~/.codex/config.toml` directly:
+
+```bash
+codex mcp add coreui-docs -- npx -y @coreui/docs-mcp --framework react
+```
+
+```toml
+[mcp_servers.coreui-docs]
+command = "npx"
+args = ["-y", "@coreui/docs-mcp", "--framework", "react"]
 ```
 
 ## Tools
@@ -55,5 +122,14 @@ Once connected, your assistant can call the following tools:
 | `--base-url <url>` | `COREUI_DOCS_BASE_URL` | `https://coreui.io` | Origin of the CoreUI site. The `/<framework>/docs` path is appended automatically — override only for a staging or self-hosted mirror. |
 | `--ttl <minutes>` | `COREUI_DOCS_TTL_MINUTES` | `360` | Cache freshness window. |
 | — | `COREUI_DOCS_CACHE_DIR` | OS cache directory | On-disk cache location. |
+
+## Example prompts
+
+Once installed, try asking your AI assistant:
+
+- "How do I use the CoreUI React Multi Select component?"
+- "What props does the CoreUI React Date Picker accept?"
+- "Show me the CoreUI React Modal documentation."
+- "Where is the Accordion documented across CoreUI frameworks?"
 
 The package is open source and published as [`@coreui/docs-mcp`](https://www.npmjs.com/package/@coreui/docs-mcp).

--- a/packages/docs/src/content/docs/getting-started/llms-txt.mdx
+++ b/packages/docs/src/content/docs/getting-started/llms-txt.mdx
@@ -1,0 +1,29 @@
+---
+title: "LLMs.txt"
+name: "LLMs.txt"
+description: "LLM-optimized documentation endpoints for CoreUI for React — llms.txt, llms-full.txt, and a Markdown version of every page."
+---
+
+## Introduction
+
+[llms.txt](https://llmstxt.org) is an emerging standard that helps AI models understand and navigate documentation. The CoreUI for React docs expose three LLM-friendly endpoints so assistants can retrieve accurate, up-to-date content straight from the source.
+
+For a richer, tool-based integration, see [AI Tools (MCP)](/react/docs/getting-started/ai-tools/).
+
+## /llms.txt
+
+A structured index of the documentation — every page as a titled, described link, grouped by section. It gives an LLM a compact map of what exists and where.
+
+[Open llms.txt](/react/docs/llms.txt)
+
+## /llms-full.txt
+
+The entire documentation concatenated into a single Markdown file, so a model can ingest the whole set in one request.
+
+[Open llms-full.txt](/react/docs/llms-full.txt)
+
+## Markdown version of any page
+
+Append `.md` to any documentation page URL to get its clean Markdown version, without the site chrome.
+
+For example: [/react/docs/components/accordion.md](/react/docs/components/accordion.md)

--- a/packages/docs/src/data/sidebar.yml
+++ b/packages/docs/src/data/sidebar.yml
@@ -5,10 +5,13 @@
       to: /getting-started/introduction/
     - title: Accessibility
       to: /getting-started/accessibility/
+- title: AI Tools
+  icon: <path fill="var(--ci-primary-color, currentColor)" d="M472 40H40a24.03 24.03 0 0 0-24 24v392a24.03 24.03 0 0 0 24 24h432a24.03 24.03 0 0 0 24-24V64a24.03 24.03 0 0 0-24-24m-8 408H48V72h416Z" class="ci-primary"></path><path fill="var(--ci-primary-color, currentColor)" d="m115.962 282.627 73.445-82.672-73.451-82.588-23.912 21.266 54.549 61.333-54.555 61.407zM216 240h128v32H216z" class="ci-primary"></path>
+  pages:
     - title: LLMs.txt
-      to: /getting-started/llms-txt/
-    - title: AI Tools (MCP)
-      to: /getting-started/ai-tools/
+      to: /ai-tools/llms-txt/
+    - title: MCP Server
+      to: /ai-tools/mcp/
 - title: Customize
   icon: <path fill="var(--ci-primary-color, currentColor)" d="M425.514,82.055C380.778,39.458,320.673,16,256.271,16,196.248,16,136.415,36.073,92.115,71.071,43.032,109.85,16,164.161,16,224c0,60.1,15.531,98.87,48.876,122.019,28,19.438,68.412,27.731,135.124,27.731h29.75A26.28,26.28,0,0,1,256,400v47.984a32,32,0,0,0,32,32h.032l90.755-.088a32.094,32.094,0,0,0,19.686-6.8c9.725-7.622,34.727-29.4,56.8-66.9C482.3,360.262,496,307.037,496,248,496,184.268,470.968,125.334,425.514,82.055Zm2.173,307.915c-19.3,32.792-40.663,51.447-48.932,57.926L288,447.984V400a58.316,58.316,0,0,0-58.25-58.25H200c-59.69,0-94.644-6.585-116.876-22.019C58.833,302.869,48,273.344,48,224,48,113.833,153.9,48,256.271,48,372.755,48,464,135.851,464,248,464,301.253,451.782,349.019,427.687,389.97Z" class="ci-primary"/><path fill="var(--ci-primary-color, currentColor)" d="M128,144a56,56,0,1,0,56,56A56.064,56.064,0,0,0,128,144Zm0,80a24,24,0,1,1,24-24A24.027,24.027,0,0,1,128,224Z" class="ci-primary"/><path fill="var(--ci-primary-color, currentColor)" d="M240,72a56,56,0,1,0,56,56A56.064,56.064,0,0,0,240,72Zm0,80a24,24,0,1,1,24-24A24.027,24.027,0,0,1,240,152Z" class="ci-primary"/><path fill="var(--ci-primary-color, currentColor)" d="M360,128a56,56,0,1,0,56,56A56.064,56.064,0,0,0,360,128Zm0,80a24,24,0,1,1,24-24A24.027,24.027,0,0,1,360,208Z" class="ci-primary"/><path fill="var(--ci-primary-color, currentColor)" d="M376,264a56,56,0,1,0,56,56A56.064,56.064,0,0,0,376,264Zm0,80a24,24,0,1,1,24-24A24.027,24.027,0,0,1,376,344Z" class="ci-primary"/>
   pages:

--- a/packages/docs/src/data/sidebar.yml
+++ b/packages/docs/src/data/sidebar.yml
@@ -5,6 +5,8 @@
       to: /getting-started/introduction/
     - title: Accessibility
       to: /getting-started/accessibility/
+    - title: LLMs.txt
+      to: /getting-started/llms-txt/
     - title: AI Tools (MCP)
       to: /getting-started/ai-tools/
 - title: Customize


### PR DESCRIPTION
Adds a dedicated **AI Tools** section to the docs with two pages:

- **MCP Server** (`/ai-tools/mcp/`) — full setup guide for the `@coreui/docs-mcp` Model Context Protocol server: capabilities, per-client install (Claude Code, Cursor, VS Code with the correct `servers` key, Windsurf, Claude Desktop, OpenAI Codex), tools, configuration, and example prompts.
- **LLMs.txt** (`/ai-tools/llms-txt/`) — documents the already-served `llms.txt`, `llms-full.txt`, and per-page `.md` endpoints.

Adds an "AI Tools" sidebar group (terminal icon) after Getting Started.