### PR TITLE
docs: fix broken internal links (dead API-ref sections, relative paths)

### DIFF
--- a/packages/docs/src/content/docs/components/button-group/bootstrap.mdx
+++ b/packages/docs/src/content/docs/components/button-group/bootstrap.mdx
@@ -42,7 +42,7 @@ The React Bootstrap Button Group component allows you to group multiple buttons 
   Always include an accessible label using `aria-label` or `aria-labelledby` to clarify the purpose of the group.
 </Callout>
 
-React Bootstrap Button Groups can also be applied to a group of links instead of using the [`CNav`](./../navs-tabs/#base-nav) component.
+React Bootstrap Button Groups can also be applied to a group of links instead of using the [`CNav`](../../navs-tabs/#base-nav) component.
 
 <Example code={ButtonGroup2ExampleRaw} name="ButtonGroup2Example" componentName="React Bootstrap Button Group" class="theme-bootstrap">
   <ButtonGroup2Example client:only="react" />

--- a/packages/docs/src/content/docs/components/tooltip/bootstrap.mdx
+++ b/packages/docs/src/content/docs/components/tooltip/bootstrap.mdx
@@ -29,7 +29,7 @@ Hover over the links below to see Bootstrap-style tooltips.
 
 ### Custom tooltips
 
-You can customize the appearance of tooltips using [CSS variables](./styling/#css-variables). Below is an example with scoped overrides for a unique appearance.
+You can customize the appearance of tooltips using [CSS variables](../styling/#css-variables). Below is an example with scoped overrides for a unique appearance.
 
 <Example code={TooltipCustomExampleRaw} codeJs={TooltipCustomExampleJsRaw} name="TooltipCustomExample" componentName="React Bootstrap Tooltip" class="theme-bootstrap text-body-secondary">
   <TooltipCustomExample client:only="react" />

--- a/packages/docs/src/content/docs/forms/layout/bootstrap.mdx
+++ b/packages/docs/src/content/docs/forms/layout/bootstrap.mdx
@@ -103,14 +103,3 @@ Use inline layouts to group form controls in a horizontal row, perfect for compa
 <Example code={LayoutInlineFormsExampleRaw} name="LayoutInlineFormsExample" componentName="React Bootstrap Form Layout" class="theme-bootstrap">
   <LayoutInlineFormsExample client:only="react" />
 </Example>
-
-## API reference
-
-Check out the documentation below for a comprehensive guide to all the props you can use with the components mentioned here.
-
-- [&lt;CForm /&gt;](../api/#cform)
-- [&lt;CRow /&gt;](../api/#crow)
-- [&lt;CCol /&gt;](../api/#ccol)
-- [&lt;CFormLabel /&gt;](../api/#cformlabel)
-- [&lt;CFormCheck /&gt;](../api/#cformcheck)
-- [&lt;CFormInput /&gt;](../api/#cforminput)

--- a/packages/docs/src/content/docs/forms/validation/bootstrap.mdx
+++ b/packages/docs/src/content/docs/forms/validation/bootstrap.mdx
@@ -66,14 +66,3 @@ For compact layouts, validation messages can appear as tooltips. Make sure the p
 <Example code={ValidationTooltipsExampleRaw} codeJs={ValidationTooltipsExampleJsRaw} name="ValidationTooltipsExample" componentName="React Bootstrap Form Validation" class="theme-bootstrap">
   <ValidationTooltipsExample client:only="react" />
 </Example>
-
-## API reference
-
-Refer to the API documentation for detailed descriptions of the props and features available:
-
-- [&lt;CForm /&gt;](../api/#cform)
-- [&lt;CFormCheck /&gt;](../api/#cformcheck)
-- [&lt;CFormInput /&gt;](../api/#cforminput)
-- [&lt;CFormSelect /&gt;](../api/#cformselect)
-- [&lt;CFormTextarea /&gt;](../api/#cformtextarea)
-- [&lt;CFormFeedback /&gt;](../api/#cformfeedback)

--- a/packages/docs/src/content/docs/layout/gutters.mdx
+++ b/packages/docs/src/content/docs/layout/gutters.mdx
@@ -96,7 +96,7 @@ An alternative solution is to add a wrapper around the `<CRow>` with the `.overf
 
 ## Row columns gutters
 
-Gutter props can also be added to [row columns](../layout/grid#row-columns). In the following example, we use responsive row columns and responsive gutter props.
+Gutter props can also be added to [row columns](../grid#row-columns). In the following example, we use responsive row columns and responsive gutter props.
 
 ```jsx preview className="docs-example m-0 border-0 docs-example-cols"
 <CContainer>


### PR DESCRIPTION
Fixes broken internal links surfaced by astro-broken-links-checker:

- Remove the dead "API reference" sections from `forms/layout/bootstrap.mdx` and `forms/validation/bootstrap.mdx` (they linked to a per-page `../api/` that these guide pages do not have; the `index.mdx` variants have no such section).
- Fix off-by-one relative paths on the deeper `bootstrap`/`styling` variant pages: `../layout/grid` -> `../grid` (gutters), `./../navs-tabs/` -> `../../navs-tabs/` (button-group), `./styling/` -> `../styling/` (tooltip).