### PR TITLE
docs: add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,7 @@
+# Reporting Security Issues
+
+The CoreUI team and community take security issues in CoreUI seriously. We appreciate your efforts to responsibly disclose your findings, and will make every effort to acknowledge your contributions.
+
+To report a security issue, email [support@coreui.io](mailto:support@coreui.io) and include the word "SECURITY" in the subject line.
+
+We'll endeavor to respond quickly, and will keep you updated throughout the process.


### PR DESCRIPTION
Adds a security policy so GitHub's Security tab has a defined private reporting path, matching `coreui`/`coreui-pro`. Verbatim copy of the canonical CoreUI `SECURITY.md` (report to support@coreui.io with "SECURITY" in the subject). Closes part of supply-chain audit #5.