### PR TITLE
chore(package): exclude __tests__ from the published tarball

### DIFF
--- a/packages/coreui-react/package.json
+++ b/packages/coreui-react/package.json
@@ -29,7 +29,8 @@
   "types": "dist/esm/index.d.ts",
   "files": [
     "dist/",
-    "src/"
+    "src/",
+    "!src/**/__tests__"
   ],
   "sideEffects": false,
   "scripts": {


### PR DESCRIPTION
## Packaging fix (from the July 2026 packaging audit, Top-5 #5)

The `"src/"` whitelist shipped ~250 test + snapshot files (`__tests__`/`__snapshots__`) with zero consumer value. Added `"!src/**/__tests__"` to `files` — drops them while keeping the source and source maps for consumers who want them.

Verified with `npm pack --dry-run`: **0 test files remaining, `dist/` untouched** (1176 dist files intact). All `__snapshots__` live inside `__tests__`, so the single glob covers both.

Metadata-only change; no source touched.