### PR TITLE
ci: make Lint a required check (drop continue-on-error)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,6 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
-    # Non-blocking for now: a handful of react-hooks v7 findings and one
-    # deferred public type are still open. Drop continue-on-error once the
-    # remaining errors are resolved to make lint a required check.
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
Makes the CI **Lint** job a required check by dropping `continue-on-error: true`.

It was set non-blocking while a few react-hooks v7 findings were open. Those remaining findings are now **warnings** (the compiler rules `react-hooks/refs`, `set-state-in-effect`, `static-components` are pinned to `warn`; `exhaustive-deps` stays `warn`), while `react-hooks/rules-of-hooks` remains an **error** — so a genuine hook-correctness regression now fails the PR again.

Verified the CI-relevant lint is clean: `npm run lint` over the checked-out tree (main library + docs; the `coreui-icons-react` / `coreui-react-chartjs` submodules are not checked out in CI) reports **0 errors**. No source changes needed.