### PR TITLE
chore(docs): bump @coreui/astro-docs to 0.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -335,6 +335,31 @@
         "unified": "^11.0.5"
       }
     },
+    "node_modules/@astrojs/markdown-remark": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-7.2.1.tgz",
+      "integrity": "sha512-jPVNIqTvk+yKviikszv/Y1U4jGUSKpp/Nw48QZV4qjWgp70j4Lkq3lhSDRbWwCfgKvEyO9GHuVbV1dM2WYXy1w==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/internal-helpers": "0.10.1",
+        "@astrojs/prism": "4.0.2",
+        "github-slugger": "^2.0.0",
+        "hast-util-from-html": "^2.0.3",
+        "hast-util-to-text": "^4.0.2",
+        "mdast-util-definitions": "^6.0.0",
+        "rehype-raw": "^7.0.0",
+        "rehype-stringify": "^10.0.1",
+        "remark-gfm": "^4.0.1",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.1.2",
+        "remark-smartypants": "^3.0.2",
+        "unified": "^11.0.5",
+        "unist-util-remove-position": "^5.0.0",
+        "unist-util-visit": "^5.1.0",
+        "unist-util-visit-parents": "^6.0.2",
+        "vfile": "^6.0.3"
+      }
+    },
     "node_modules/@astrojs/markdown-satteri": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/@astrojs/markdown-satteri/-/markdown-satteri-0.3.4.tgz",
@@ -346,6 +371,40 @@
         "github-slugger": "^2.0.0",
         "hast-util-from-html": "^2.0.3",
         "satteri": "^0.9.1"
+      }
+    },
+    "node_modules/@astrojs/mdx": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@astrojs/mdx/-/mdx-7.0.3.tgz",
+      "integrity": "sha512-RxyIwU0uFam5ftwqKOjpIdhnFxZ/kEikeimLyQy3eGXbHT8WgRGzzesOIHVU8+m9TY8ag5WVOyvV24/GyqPdPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/internal-helpers": "0.10.1",
+        "@astrojs/markdown-remark": "7.2.1",
+        "@mdx-js/mdx": "^3.1.1",
+        "acorn": "^8.16.0",
+        "es-module-lexer": "^2.0.0",
+        "estree-util-visit": "^2.0.0",
+        "hast-util-to-html": "^9.0.5",
+        "piccolore": "^0.1.3",
+        "rehype-raw": "^7.0.0",
+        "remark-gfm": "^4.0.1",
+        "remark-smartypants": "^3.0.2",
+        "source-map": "^0.7.6",
+        "unist-util-visit": "^5.1.0",
+        "vfile": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      },
+      "peerDependencies": {
+        "@astrojs/markdown-satteri": "^0.3.1",
+        "astro": "^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@astrojs/markdown-satteri": {
+          "optional": true
+        }
       }
     },
     "node_modules/@astrojs/prism": {
@@ -1159,6 +1218,53 @@
       },
       "engines": {
         "node": ">= 20.12.0"
+      }
+    },
+    "node_modules/@coreui/astro-docs": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@coreui/astro-docs/-/astro-docs-0.1.1.tgz",
+      "integrity": "sha512-ucFQ2TzMi9iR35eZ3FRvyanIi+9P+TBTffnHrtuwQ2GKcCxKb38zeLs68iWo2sPDWPf7K28IZq2xNnpXzLA07Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@coreui/icons": "^3.1.0",
+        "@coreui/internal-links": "^5.2.0",
+        "@docsearch/css": "^4.6.3",
+        "@docsearch/js": "^4.6.3",
+        "@stackblitz/sdk": "^1.11.1",
+        "astro-auto-import": "^0.5.2",
+        "astro-broken-links-checker": "^1.1.0",
+        "js-yaml": "^5.2.1",
+        "lz-string": "^1.5.0",
+        "rehype-autolink-headings": "^7.1.0",
+        "unist-util-visit": "^5.1.0",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@astrojs/markdown-remark": "^7.2.0",
+        "@astrojs/mdx": "^7.0.0",
+        "astro": "^7.0.0"
+      }
+    },
+    "node_modules/@coreui/astro-docs/node_modules/js-yaml": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.1.tgz",
+      "integrity": "sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.mjs"
       }
     },
     "node_modules/@coreui/chartjs": {
@@ -7581,6 +7687,21 @@
         "@astrojs/markdown-remark": {
           "optional": true
         }
+      }
+    },
+    "node_modules/astro-auto-import": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/astro-auto-import/-/astro-auto-import-0.5.2.tgz",
+      "integrity": "sha512-C7sxtj0nK4F7AiafNoS8lY/JyqW6/JlnkXTdNIT6CKroV/p4m5j6dkpKEAXZf/7Z+SeDcmAlWI6G1nVMssRRPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.17.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "astro": "^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
     "node_modules/astro-broken-links-checker": {
@@ -24603,7 +24724,7 @@
     },
     "packages/coreui-react": {
       "name": "@coreui/react",
-      "version": "5.12.0",
+      "version": "5.13.0",
       "license": "MIT",
       "dependencies": {
         "@coreui/coreui": "^5.9.0",
@@ -25708,7 +25829,7 @@
       "dependencies": {
         "@astrojs/mdx": "^7.0.3",
         "@astrojs/react": "^6.0.1",
-        "@coreui/astro-docs": "0.1.0",
+        "@coreui/astro-docs": "0.1.1",
         "@coreui/chartjs": "^4.2.0",
         "@coreui/coreui": "^5.9.0",
         "@coreui/icons": "^3.1.0",
@@ -25726,65 +25847,6 @@
       "devDependencies": {
         "@coreui/astro-docs-api-generator": "0.1.0",
         "typescript": "^5.9.3"
-      }
-    },
-    "packages/docs/node_modules/@astrojs/markdown-remark": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-7.2.1.tgz",
-      "integrity": "sha512-jPVNIqTvk+yKviikszv/Y1U4jGUSKpp/Nw48QZV4qjWgp70j4Lkq3lhSDRbWwCfgKvEyO9GHuVbV1dM2WYXy1w==",
-      "license": "MIT",
-      "dependencies": {
-        "@astrojs/internal-helpers": "0.10.1",
-        "@astrojs/prism": "4.0.2",
-        "github-slugger": "^2.0.0",
-        "hast-util-from-html": "^2.0.3",
-        "hast-util-to-text": "^4.0.2",
-        "mdast-util-definitions": "^6.0.0",
-        "rehype-raw": "^7.0.0",
-        "rehype-stringify": "^10.0.1",
-        "remark-gfm": "^4.0.1",
-        "remark-parse": "^11.0.0",
-        "remark-rehype": "^11.1.2",
-        "remark-smartypants": "^3.0.2",
-        "unified": "^11.0.5",
-        "unist-util-remove-position": "^5.0.0",
-        "unist-util-visit": "^5.1.0",
-        "unist-util-visit-parents": "^6.0.2",
-        "vfile": "^6.0.3"
-      }
-    },
-    "packages/docs/node_modules/@astrojs/mdx": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@astrojs/mdx/-/mdx-7.0.3.tgz",
-      "integrity": "sha512-RxyIwU0uFam5ftwqKOjpIdhnFxZ/kEikeimLyQy3eGXbHT8WgRGzzesOIHVU8+m9TY8ag5WVOyvV24/GyqPdPQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@astrojs/internal-helpers": "0.10.1",
-        "@astrojs/markdown-remark": "7.2.1",
-        "@mdx-js/mdx": "^3.1.1",
-        "acorn": "^8.16.0",
-        "es-module-lexer": "^2.0.0",
-        "estree-util-visit": "^2.0.0",
-        "hast-util-to-html": "^9.0.5",
-        "piccolore": "^0.1.3",
-        "rehype-raw": "^7.0.0",
-        "remark-gfm": "^4.0.1",
-        "remark-smartypants": "^3.0.2",
-        "source-map": "^0.7.6",
-        "unist-util-visit": "^5.1.0",
-        "vfile": "^6.0.3"
-      },
-      "engines": {
-        "node": ">=22.12.0"
-      },
-      "peerDependencies": {
-        "@astrojs/markdown-satteri": "^0.3.1",
-        "astro": "^7.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@astrojs/markdown-satteri": {
-          "optional": true
-        }
       }
     },
     "packages/docs/node_modules/@astrojs/react": {
@@ -25809,31 +25871,6 @@
         "react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0"
       }
     },
-    "packages/docs/node_modules/@coreui/astro-docs": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@coreui/astro-docs/-/astro-docs-0.1.0.tgz",
-      "integrity": "sha512-pmi5f4qz90TqWUXwffjdDWEY3FCP1DIDXyw7bHhIHTy1AVWXM7aUU482UxnKH5zWDstKNx7b0dgZgS8aXMxl6g==",
-      "license": "MIT",
-      "dependencies": {
-        "@astrojs/markdown-remark": "^7.2.1",
-        "@coreui/icons": "^3.1.0",
-        "@coreui/internal-links": "^5.2.0",
-        "@docsearch/css": "^4.6.3",
-        "@docsearch/js": "^4.6.3",
-        "@stackblitz/sdk": "^1.11.1",
-        "astro-auto-import": "^0.5.2",
-        "astro-broken-links-checker": "^1.1.0",
-        "js-yaml": "^5.2.1",
-        "lz-string": "^1.5.0",
-        "rehype-autolink-headings": "^7.1.0",
-        "unist-util-visit": "^5.1.0",
-        "zod": "^4.4.3"
-      },
-      "peerDependencies": {
-        "@astrojs/mdx": "^7.0.0",
-        "astro": "^7.0.0"
-      }
-    },
     "packages/docs/node_modules/@coreui/astro-docs-api-generator": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@coreui/astro-docs-api-generator/-/astro-docs-api-generator-0.1.0.tgz",
@@ -25847,28 +25884,6 @@
       },
       "bin": {
         "coreui-docs-api": "bin/coreui-docs-api.mjs"
-      }
-    },
-    "packages/docs/node_modules/@coreui/astro-docs/node_modules/js-yaml": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.1.tgz",
-      "integrity": "sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.mjs"
       }
     },
     "packages/docs/node_modules/@coreui/coreui": {
@@ -25910,21 +25925,6 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "packages/docs/node_modules/astro-auto-import": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/astro-auto-import/-/astro-auto-import-0.5.2.tgz",
-      "integrity": "sha512-C7sxtj0nK4F7AiafNoS8lY/JyqW6/JlnkXTdNIT6CKroV/p4m5j6dkpKEAXZf/7Z+SeDcmAlWI6G1nVMssRRPQ==",
-      "license": "MIT",
-      "dependencies": {
-        "acorn": "^8.17.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "astro": "^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
     "packages/docs/node_modules/react": {

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@astrojs/mdx": "^7.0.3",
     "@astrojs/react": "^6.0.1",
-    "@coreui/astro-docs": "0.1.0",
+    "@coreui/astro-docs": "0.1.1",
     "@coreui/chartjs": "^4.2.0",
     "@coreui/coreui": "^5.9.0",
     "@coreui/icons": "^3.1.0",


### PR DESCRIPTION
0.1.1 moves `@astrojs/markdown-remark` to a peer dependency, fixing the docs build on Astro 7.1.2 — whose Sätteri default no longer installs markdown-remark at the workspace root. Verified: docs build (204 pages, no broken links).