### PR TITLE
chore(deps): bump the docs engine to @coreui/astro-docs 0.1.2, api-generator 0.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1221,11 +1221,12 @@
       }
     },
     "node_modules/@coreui/astro-docs": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@coreui/astro-docs/-/astro-docs-0.1.1.tgz",
-      "integrity": "sha512-ucFQ2TzMi9iR35eZ3FRvyanIi+9P+TBTffnHrtuwQ2GKcCxKb38zeLs68iWo2sPDWPf7K28IZq2xNnpXzLA07Q==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@coreui/astro-docs/-/astro-docs-0.1.2.tgz",
+      "integrity": "sha512-00VA8E5XPYD0nAEto7anu7ZXMAq5gljlZT6UL9TmswL/aLtuLmElZYqewlpg9Qo4PS3C7rH4QKZR+dxudjuiBA==",
       "license": "MIT",
       "dependencies": {
+        "@coreui/chartjs": "^4.2.0",
         "@coreui/icons": "^3.1.0",
         "@coreui/internal-links": "^5.2.0",
         "@docsearch/css": "^4.6.3",
@@ -1233,7 +1234,7 @@
         "@stackblitz/sdk": "^1.11.1",
         "astro-auto-import": "^0.5.2",
         "astro-broken-links-checker": "^1.1.0",
-        "js-yaml": "^5.2.1",
+        "js-yaml": "^5.2.2",
         "lz-string": "^1.5.0",
         "rehype-autolink-headings": "^7.1.0",
         "unist-util-visit": "^5.1.0",
@@ -1242,13 +1243,28 @@
       "peerDependencies": {
         "@astrojs/markdown-remark": "^7.2.0",
         "@astrojs/mdx": "^7.0.0",
-        "astro": "^7.0.0"
+        "astro": "^7.1.3"
+      }
+    },
+    "node_modules/@coreui/astro-docs-api-generator": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@coreui/astro-docs-api-generator/-/astro-docs-api-generator-0.2.0.tgz",
+      "integrity": "sha512-iPbM5rKW9Mep80dNHJUr8pjscCb7qELhfaNJ9+W0qDnXk1ExCuH9vAV5t+33auI/A2A00464bpplNWhDm8GRCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "react-docgen-typescript": "^2.4.0",
+        "typedoc": "^0.28.20",
+        "vue-docgen-api": "^4.79.2"
+      },
+      "bin": {
+        "coreui-docs-api": "bin/coreui-docs-api.mjs"
       }
     },
     "node_modules/@coreui/astro-docs/node_modules/js-yaml": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.1.tgz",
-      "integrity": "sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.2.tgz",
+      "integrity": "sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw==",
       "funding": [
         {
           "type": "github",
@@ -7606,9 +7622,9 @@
       }
     },
     "node_modules/astro": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-7.1.2.tgz",
-      "integrity": "sha512-rn7bsh2n2/Wm/blS7QO6+aKstNfEOygX35cACGQJP8tM2uLRfeNTTEawrUR6NpVr27mOMGnl6CSWQ0CNb8iGZA==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-7.1.4.tgz",
+      "integrity": "sha512-e0gkBReJECAZuuTgpEB5JMUc6J4mM6boD6wuVE1pBf/fMywG47f8qm9XQoA6kZB1RWHiHmUlLuQ2jd9Q5+72HQ==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/compiler-rs": "^0.3.1",
@@ -7639,7 +7655,7 @@
         "http-cache-semantics": "^4.2.0",
         "js-yaml": "^4.1.1",
         "jsonc-parser": "^3.3.1",
-        "magic-string": "^0.30.21",
+        "magic-string": "^1.0.0",
         "magicast": "^0.5.2",
         "mrmime": "^2.0.1",
         "neotraverse": "^1.0.1",
@@ -7734,6 +7750,15 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
+      }
+    },
+    "node_modules/astro/node_modules/magic-string": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.1.0.tgz",
+      "integrity": "sha512-kS3VHe0nEPST2saQV4Rbkchcd3UBRkVTQHo1D3h/ZTwFDhai/mfKkmtPAtD129EOI7K3HlHIsFOt0WrI2/oU9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/astro/node_modules/unstorage": {
@@ -16317,6 +16342,7 @@
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
@@ -25829,7 +25855,7 @@
       "dependencies": {
         "@astrojs/mdx": "^7.0.3",
         "@astrojs/react": "^6.0.1",
-        "@coreui/astro-docs": "0.1.1",
+        "@coreui/astro-docs": "0.1.2",
         "@coreui/chartjs": "^4.2.0",
         "@coreui/coreui": "^5.9.0",
         "@coreui/icons": "^3.1.0",
@@ -25845,7 +25871,7 @@
         "sass": "^1.101.0"
       },
       "devDependencies": {
-        "@coreui/astro-docs-api-generator": "0.1.0",
+        "@coreui/astro-docs-api-generator": "0.2.0",
         "typescript": "^5.9.3"
       }
     },
@@ -25869,21 +25895,6 @@
         "@types/react-dom": "^17.0.17 || ^18.0.6 || ^19.0.0",
         "react": "^17.0.2 || ^18.0.0 || ^19.0.0",
         "react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "packages/docs/node_modules/@coreui/astro-docs-api-generator": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@coreui/astro-docs-api-generator/-/astro-docs-api-generator-0.1.0.tgz",
-      "integrity": "sha512-x18VYTEUHRa2dQ4A8YLEgGrGC2NNB5EqOXCC3rDAkPEBGkjTqhxdX2tx3HM3Yb2mj0y86dGvHQ522BpFxtVUZw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "react-docgen-typescript": "^2.4.0",
-        "typedoc": "^0.28.20",
-        "vue-docgen-api": "^4.79.2"
-      },
-      "bin": {
-        "coreui-docs-api": "bin/coreui-docs-api.mjs"
       }
     },
     "packages/docs/node_modules/@coreui/coreui": {

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@astrojs/mdx": "^7.0.3",
     "@astrojs/react": "^6.0.1",
-    "@coreui/astro-docs": "0.1.1",
+    "@coreui/astro-docs": "0.1.2",
     "@coreui/chartjs": "^4.2.0",
     "@coreui/coreui": "^5.9.0",
     "@coreui/icons": "^3.1.0",
@@ -29,7 +29,7 @@
     "sass": "^1.101.0"
   },
   "devDependencies": {
-    "@coreui/astro-docs-api-generator": "0.1.0",
+    "@coreui/astro-docs-api-generator": "0.2.0",
     "typescript": "^5.9.3"
   }
 }


### PR DESCRIPTION
Picks up the docs-engine release: Chart.js tooltip styles bundled into the docs build, example tabs labelled by role, and the Angular sandbox fixes; the API generator adds Angular-from-package support and a batch of extractor fixes. Lockfile also refreshes `astro` (the engine's peer range moved to `^7.1.3`).

Verified: `docs:build` against the released engine source is green across every edition (React/Vue PRO, Angular docs, Data Grid ×4).