### PR TITLE
chore(dependabot): automate only minors and patches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,32 +32,25 @@ updates:
     versioning-strategy: increase
     rebase-strategy: disabled
     ignore:
-      # react/react-dom are pinned to 18.3.1 via package.json "overrides"
-      - dependency-name: "react"
+      # only minors and patches are automated; majors are coordinated upgrades taken
+      # by hand — a single unusable one (typescript 7, blocked by typescript-eslint's
+      # peer range) otherwise holds the whole group PR hostage
+      - dependency-name: "*"
         update-types:
           - "version-update:semver-major"
-      - dependency-name: "react-dom"
+      # 0.x packages — a minor release is a breaking release
+      - dependency-name: "@coreui/astro-docs*"
         update-types:
-          - "version-update:semver-major"
-      # docs engine — Astro majors are coordinated migrations, bumped by hand
-      - dependency-name: "astro"
-        update-types:
-          - "version-update:semver-major"
-      - dependency-name: "@astrojs/*"
-        update-types:
-          - "version-update:semver-major"
+          - "version-update:semver-minor"
       # linter churn — new rules break CI; bump deliberately
       - dependency-name: "eslint*"
         update-types:
-          - "version-update:semver-major"
           - "version-update:semver-minor"
       - dependency-name: "typescript-eslint"
         update-types:
-          - "version-update:semver-major"
           - "version-update:semver-minor"
       - dependency-name: "@typescript-eslint/*"
         update-types:
-          - "version-update:semver-major"
           - "version-update:semver-minor"
     groups:
       production-dependencies:


### PR DESCRIPTION
Dependabot now proposes only minor and patch updates; majors are taken by hand as coordinated upgrades.

The trigger: the weekly `development-dependencies` group PRs bundled three harmless patches with five majors (typescript 7.0.2, stylelint 17, eslint-plugin-unicorn 72, jasmine 6, globals 17), so the whole PR went red and nothing landed. TypeScript 7 in particular is not adoptable anywhere — the latest `typescript-eslint` (8.66.0) still declares `peer typescript >=4.8.4 <6.1.0`.

- a single `dependency-name: "*"` rule ignores every semver-major, which makes the previous per-package major ignores (astro, @astrojs/*, @babel/*, eslint, react, react-dom, …) redundant — removed
- 0.x packages get an explicit minor guard, since for them a minor release is a breaking release
- entries that block minors as well (eslint*, typescript-eslint, karma*, jquery, vnu-jar, eslint-config-xo) are kept as they were
- github-actions updates are untouched: action majors track runner deprecations and CI verifies them immediately

Note: an ignore rule also suppresses a security update whose only fix is a major. Those still surface as Dependabot alerts and are handled by hand.