### PR TITLE
chore(build): set an explicit rootDir for declaration output

### DIFF
--- a/packages/coreui-react/tsconfig.json
+++ b/packages/coreui-react/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../../tsconfig",
+  "compilerOptions": {
+    "rootDir": "src"
+  },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
Preventive — this repo is **not** currently broken. It hardens the build against a defect that already shipped in the pro packages.

## Background

`package.json` points `types` at `dist/esm/index.d.ts`. Emitting the entry declarations anywhere else silently breaks every TypeScript consumer with `TS7016` on every import, while the runtime keeps working — the JavaScript entry is unaffected because rollup applies its own `preserveModulesRoot: 'src'`.

That is exactly what happened to `@coreui/react-pro` (from 5.27.0) and `@coreui/vue-pro` (from 5.20.0, reported as coreui/coreui-pro#704): the declarations moved to `dist/esm/src/index.d.ts` and `dist/cjs/src/index.d.ts`.

## Cause, and why this repo escaped it

It takes two ingredients:

1. `@rollup/plugin-typescript` **12.x** no longer sets `rootDir` itself.
2. TypeScript **6.x** no longer infers the common source directory:

   ```
   TS5011: The common source directory of 'tsconfig.json' is './src'.
   The 'rootDir' setting must be explicitly set to this or another path
   to adjust your output's file layout.
   ```

The pro repos have both. This repo already resolves TypeScript 6.x (transitive dependencies lifted it to the root, where the hoisted plugin picks it up regardless of the `typescript@^5.9.3` pin), but is still on plugin **11.1.6**, which sets `rootDir` on its own. So today's output is correct and the next plugin bump would break it.

## Fix

Set `rootDir` explicitly — exactly what TS5011 asks for. This makes the output layout independent of the plugin and compiler versions.

## Verification

Built ESM + CJS before and after: output is byte-for-byte the same layout, with the entry declarations at `dist/esm/index.d.ts` and `dist/cjs/index.d.ts` and no `src/` segment.