### PR TITLE
docs: add Data Grid section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
 - [Documentation](#documentation)
 - [Frameworks](#frameworks)
 - [Templates](#templates)
+- [Data Grid](#data-grid)
 - [Contributing](#contributing)
 - [Community](#community)
 - [Versioning](#versioning)
@@ -191,6 +192,19 @@ Fully featured, out-of-the-box, templates for your application based on CoreUI.
 - [Next.js Admin Templates](https://coreui.io/themes-templates/admin-dashboard/next-js/)
 - [React Admin Templates](https://coreui.io/themes-templates/admin-dashboard/react/)
 - [Vue Admin Templates](https://coreui.io/themes-templates/admin-dashboard/vue/)
+
+## Data Grid
+
+CoreUI React Data Grid handles 100,000+ rows with sorting, filtering, virtualization, column pinning, inline editing and CSV export — using the same markup and stylesheet you already use.
+
+```bash
+npm install @coreui/react-data-grid
+```
+
+One license also covers JavaScript, Vue and Angular. It's a separate add-on, not part of CoreUI PRO.
+
+- [React Data Grid](https://coreui.io/data-grid/react/?src=readme-react-github)
+- [Documentation](https://coreui.io/data-grid/react/docs/getting-started/introduction/?src=readme-react-github)
 
 ## Contributing
 

--- a/packages/coreui-react/README.md
+++ b/packages/coreui-react/README.md
@@ -33,6 +33,7 @@
 - [Documentation](#documentation)
 - [Frameworks](#frameworks)
 - [Templates](#templates)
+- [Data Grid](#data-grid)
 - [Contributing](#contributing)
 - [Community](#community)
 - [Versioning](#versioning)
@@ -183,6 +184,19 @@ Fully featured, out-of-the-box, templates for your application based on CoreUI.
 - [Bootstrap Admin Template](https://coreui.io/)
 - [React Admin Template](https://coreui.io/react)
 - [Vue Admin Template](https://coreui.io/vue)
+
+## Data Grid
+
+CoreUI React Data Grid handles 100,000+ rows with sorting, filtering, virtualization, column pinning, inline editing and CSV export — using the same markup and stylesheet you already use.
+
+```bash
+npm install @coreui/react-data-grid
+```
+
+One license also covers JavaScript, Vue and Angular. It's a separate add-on, not part of CoreUI PRO.
+
+- [React Data Grid](https://coreui.io/data-grid/react/?src=readme-react-npm)
+- [Documentation](https://coreui.io/data-grid/react/docs/getting-started/introduction/?src=readme-react-npm)
 
 ## Contributing
 


### PR DESCRIPTION
Adds a Data Grid section to the README.

**Why:** attach rate for Data Grid on our own install base is 0.04%. `@coreui/coreui`
and `@coreui/react` together do ~1.16M npm downloads a month; the Data Grid packages do
~1.7k. The README already promotes PRO (22–29 mentions) but never mentioned Data Grid at all.

**Framework-targeted:** each README links to its own variant — the Vue README points at
Vue Data Grid, `/data-grid/vue/` and `npm install @coreui/vue-data-grid` — so the reader
is not asked to pick. The "one license also covers …" line stays in every variant, because
multi-framework coverage is the differentiator MUI X (React only), AG Grid (separate
packages per framework) and TanStack (headless) cannot match.

**Attribution:** links carry `?src=` for first-touch tracking, matching the convention
already used in the demos. Without it the traffic lands in Direct and the change cannot
be measured.

Table of contents updated — they are maintained by hand.

All target URLs verified to return HTTP 200.