### PR TITLE
docs: add Scheduler section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@
 - [Frameworks](#frameworks)
 - [Templates](#templates)
 - [Data Grid](#data-grid)
+- [Scheduler](#scheduler)
 - [Contributing](#contributing)
 - [Community](#community)
 - [Versioning](#versioning)
@@ -205,6 +206,19 @@ One license also covers JavaScript, Vue and Angular. It's a separate add-on, not
 
 - [React Data Grid](https://coreui.io/data-grid/react/?src=readme-react-github)
 - [Documentation](https://coreui.io/data-grid/react/docs/getting-started/introduction/?src=readme-react-github)
+
+## Scheduler
+
+CoreUI React Scheduler ships six views — day, week, month, agenda, resources, and timeline — with drag & drop, RFC 5545 recurrence, and DST-safe time handling, using the same markup and stylesheet you already use.
+
+```bash
+npm install @coreui/react-scheduler
+```
+
+One license also covers JavaScript, Vue and Angular. It's a separate add-on, not part of CoreUI PRO.
+
+- [React Scheduler](https://coreui.io/scheduler/react/?src=readme-react-github)
+- [Documentation](https://coreui.io/scheduler/react/docs/getting-started/introduction/?src=readme-react-github)
 
 ## Contributing
 


### PR DESCRIPTION
Adds a `Scheduler` section to the README, mirroring the `Data Grid` section that is already there.

**Why:** `@coreui/scheduler` was published to npm on 2026-08-12 and is not mentioned anywhere in this README, while CoreUI PRO is mentioned throughout. Same reasoning as the Data Grid section — the promotion surface already exists, Scheduler is simply missing from it.

- links carry `?src=readme-*` (same value as the Data Grid links in this repo) so the traffic is attributable
- placement: right after Data Grid, plus one line in the table of contents
- no other changes