### PR TITLE
chore(deps): bump @coreui/astro-docs to 0.1.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1108,9 +1108,9 @@
       }
     },
     "node_modules/@coreui/astro-docs": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/@coreui/astro-docs/-/astro-docs-0.1.10.tgz",
-      "integrity": "sha512-o2egGMTwqlmK3SoDo00ffqWobcsEZ+miEskeZ2+/QJp+bk87S5JojTBw6Bk5L+JjuJXfEwbklRwtz+r1qXghDA==",
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@coreui/astro-docs/-/astro-docs-0.1.11.tgz",
+      "integrity": "sha512-H3RRoqDExoFbXHtqnbRrYOU5owzMTabNNzpKrJTHvK93i2yw2vF4VA3CgO61guXa7ZJs9MmBWX87sVSNe7M6RQ==",
       "license": "MIT",
       "dependencies": {
         "@coreui/chartjs": "^4.2.0",
@@ -26127,7 +26127,7 @@
       "dependencies": {
         "@astrojs/mdx": "^7.0.4",
         "@astrojs/react": "^6.0.1",
-        "@coreui/astro-docs": "0.1.10",
+        "@coreui/astro-docs": "0.1.11",
         "@coreui/chartjs": "^4.2.0",
         "@coreui/coreui": "^5.9.0",
         "@coreui/icons": "^3.1.0",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@astrojs/mdx": "^7.0.4",
     "@astrojs/react": "^6.0.1",
-    "@coreui/astro-docs": "0.1.10",
+    "@coreui/astro-docs": "0.1.11",
     "@coreui/chartjs": "^4.2.0",
     "@coreui/coreui": "^5.9.0",
     "@coreui/icons": "^3.1.0",


### PR DESCRIPTION
Carries coreui/astro-docs#89 — the docs chrome stops assuming the consuming library's palette is a legacy Sass colour. No rendered change on this line.