### PR TITLE
chore(docs): bump @coreui/astro-docs to 0.1.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1108,9 +1108,9 @@
       }
     },
     "node_modules/@coreui/astro-docs": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/@coreui/astro-docs/-/astro-docs-0.1.11.tgz",
-      "integrity": "sha512-H3RRoqDExoFbXHtqnbRrYOU5owzMTabNNzpKrJTHvK93i2yw2vF4VA3CgO61guXa7ZJs9MmBWX87sVSNe7M6RQ==",
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/@coreui/astro-docs/-/astro-docs-0.1.12.tgz",
+      "integrity": "sha512-loGvEZrHkX7CV1of2jF7oJOoT2LGOAORFXnxnzM/yU6Oa8N5og0SObjUmGTXSY7YgEtqogGr9NKp2EmXq/xgMA==",
       "license": "MIT",
       "dependencies": {
         "@coreui/chartjs": "^4.2.0",
@@ -26127,7 +26127,7 @@
       "dependencies": {
         "@astrojs/mdx": "^7.0.4",
         "@astrojs/react": "^6.0.1",
-        "@coreui/astro-docs": "0.1.11",
+        "@coreui/astro-docs": "0.1.12",
         "@coreui/chartjs": "^4.2.0",
         "@coreui/coreui": "^5.9.0",
         "@coreui/icons": "^3.1.0",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@astrojs/mdx": "^7.0.4",
     "@astrojs/react": "^6.0.1",
-    "@coreui/astro-docs": "0.1.11",
+    "@coreui/astro-docs": "0.1.12",
     "@coreui/chartjs": "^4.2.0",
     "@coreui/coreui": "^5.9.0",
     "@coreui/icons": "^3.1.0",


### PR DESCRIPTION
Bumps the docs engine pin from 0.1.11 to 0.1.12.

Gate: `npm run docs:build` passes, engine still detects edition FREE and builds in `styles mode: full`.